### PR TITLE
Fix generating with no options in `buf.gen.yaml`

### DIFF
--- a/Plugins/ConnectPluginUtilities/GeneratorOptions.swift
+++ b/Plugins/ConnectPluginUtilities/GeneratorOptions.swift
@@ -46,6 +46,10 @@ private enum CommandLineParameter: String {
         return try commandLineParameters
             .components(separatedBy: ",")
             .compactMap { parameter in
+                if parameter.isEmpty {
+                    return nil
+                }
+
                 guard let index = parameter.firstIndex(of: "=") else {
                     throw Error.unknownParameter(string: parameter)
                 }


### PR DESCRIPTION
Fixes the following error which is thrown when no `opt` is specified in `buf.gen.yaml`:

> unknownParameter(string: "")