### PR TITLE
Update `buf.yaml` for crosstests

### DIFF
--- a/Tests/ConnectLibraryTests/proto/buf.yaml
+++ b/Tests/ConnectLibraryTests/proto/buf.yaml
@@ -2,6 +2,11 @@ version: v1
 lint:
   use:
     - DEFAULT
+  ignore:
+    # We don't control these definitions, so we ignore lint errors.
+    - grpc/testing/empty.proto
+    - grpc/testing/messages.proto
+    - grpc/testing/test.proto
 breaking:
   use:
     - WIRE_JSON


### PR DESCRIPTION
Updating to match the original definitions: https://github.com/bufbuild/connect-crosstest/blob/e9ea2617c2e492572c4e0c55c0cbac5e3b447db4/internal/proto/buf.yaml#L1