### PR TITLE
Add public initializers for `ConnectError`

### DIFF
--- a/Libraries/Connect/Interfaces/ConnectError.swift
+++ b/Libraries/Connect/Interfaces/ConnectError.swift
@@ -47,6 +47,16 @@ public struct ConnectError: Swift.Error {
         }
     }
 
+    public init(
+        code: Code, message: String?, exception: Error?, details: [Detail], metadata: Headers
+    ) {
+        self.code = code
+        self.message = message
+        self.exception = exception
+        self.details = details
+        self.metadata = metadata
+    }
+
     /// Error details are sent over the network to clients, which can then work with
     /// strongly-typed data rather than trying to parse a complex error message. For
     /// example, you might use details to send a localized error message or retry
@@ -61,6 +71,11 @@ public struct ConnectError: Swift.Error {
         private enum CodingKeys: String, CodingKey {
             case type = "type"
             case payload = "value"
+        }
+
+        public init(type: String, payload: Data?) {
+            self.type = type
+            self.payload = payload
         }
     }
 }


### PR DESCRIPTION
This allows consumers to create errors in custom implementations and for testing purposes.