### PR TITLE
Add `@Sendable` to HTTP unary completion closure

### DIFF
--- a/Libraries/Connect/Implementation/URLSessionHTTPClient.swift
+++ b/Libraries/Connect/Implementation/URLSessionHTTPClient.swift
@@ -39,7 +39,7 @@ open class URLSessionHTTPClient: NSObject, HTTPClientInterface {
 
     @discardableResult
     open func unary(
-        request: HTTPRequest, completion: @escaping (HTTPResponse) -> Void
+        request: HTTPRequest, completion: @Sendable @escaping (HTTPResponse) -> Void
     ) -> Cancelable {
         let urlRequest = URLRequest(httpRequest: request)
         let task = self.session.dataTask(with: urlRequest) { data, urlResponse, error in

--- a/Libraries/Connect/Interfaces/HTTPClientInterface.swift
+++ b/Libraries/Connect/Interfaces/HTTPClientInterface.swift
@@ -21,7 +21,8 @@ public protocol HTTPClientInterface {
     ///
     /// - returns: A type which can be used to cancel the outbound request.
     @discardableResult
-    func unary(request: HTTPRequest, completion: @escaping (HTTPResponse) -> Void) -> Cancelable
+    func unary(request: HTTPRequest, completion: @Sendable @escaping (HTTPResponse) -> Void)
+        -> Cancelable
 
     /// Initialize a new HTTP stream.
     ///


### PR DESCRIPTION
This prevents a warning that can be seen with strict concurrency flags when subclassing `URLSessionHTTPClient`.