### PR TITLE
Allow building on iOS 12

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -105,7 +105,7 @@ modifier_order:
     - dynamic
     - convenience
 deployment_target:
-  iOS_deployment_target: 13.0
+  iOS_deployment_target: 12.0
 
 custom_rules:
   newline_after_brace:

--- a/Examples/ElizaSharedSources/GeneratedSources/eliza.connect.swift
+++ b/Examples/ElizaSharedSources/GeneratedSources/eliza.connect.swift
@@ -17,14 +17,17 @@ internal protocol Buf_Connect_Demo_Eliza_V1_ElizaServiceClientInterface {
 
     /// Say is a unary request demo. This method should allow for a one sentence
     /// response given a one sentence request.
+    @available(iOS 13, *)
     func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers) async -> ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse>
 
     /// Converse is a bi-directional streaming request demo. This method should allow for
     /// many requests and many responses.
+    @available(iOS 13, *)
     func `converse`(headers: Connect.Headers) -> any Connect.BidirectionalAsyncStreamInterface<Buf_Connect_Demo_Eliza_V1_ConverseRequest, Buf_Connect_Demo_Eliza_V1_ConverseResponse>
 
     /// Introduce is a server-streaming request demo.  This method allows for a single request that will return a series
     /// of responses
+    @available(iOS 13, *)
     func `introduce`(headers: Connect.Headers) -> any Connect.ServerOnlyAsyncStreamInterface<Buf_Connect_Demo_Eliza_V1_IntroduceRequest, Buf_Connect_Demo_Eliza_V1_IntroduceResponse>
 }
 
@@ -36,14 +39,17 @@ internal final class Buf_Connect_Demo_Eliza_V1_ElizaServiceClient: Buf_Connect_D
         self.client = client
     }
 
+    @available(iOS 13, *)
     internal func `say`(request: Buf_Connect_Demo_Eliza_V1_SayRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Buf_Connect_Demo_Eliza_V1_SayResponse> {
         return await self.client.unary(path: "buf.connect.demo.eliza.v1.ElizaService/Say", request: request, headers: headers)
     }
 
+    @available(iOS 13, *)
     internal func `converse`(headers: Connect.Headers = [:]) -> any Connect.BidirectionalAsyncStreamInterface<Buf_Connect_Demo_Eliza_V1_ConverseRequest, Buf_Connect_Demo_Eliza_V1_ConverseResponse> {
         return self.client.bidirectionalStream(path: "buf.connect.demo.eliza.v1.ElizaService/Converse", headers: headers)
     }
 
+    @available(iOS 13, *)
     internal func `introduce`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Buf_Connect_Demo_Eliza_V1_IntroduceRequest, Buf_Connect_Demo_Eliza_V1_IntroduceResponse> {
         return self.client.serverOnlyStream(path: "buf.connect.demo.eliza.v1.ElizaService/Introduce", headers: headers)
     }

--- a/Libraries/Connect/Implementation/ProtocolClient.swift
+++ b/Libraries/Connect/Implementation/ProtocolClient.swift
@@ -161,6 +161,7 @@ extension ProtocolClient: ProtocolClientInterface {
 
     // MARK: - Async/await
 
+    @available(iOS 13, *)
     public func unary<
         Input: SwiftProtobuf.Message, Output: SwiftProtobuf.Message
     >(
@@ -173,6 +174,7 @@ extension ProtocolClient: ProtocolClientInterface {
         }.send()
     }
 
+    @available(iOS 13, *)
     public func bidirectionalStream<
         Input: SwiftProtobuf.Message, Output: SwiftProtobuf.Message
     >(
@@ -186,6 +188,7 @@ extension ProtocolClient: ProtocolClientInterface {
         return bidirectionalAsync.configureForSending(with: callbacks)
     }
 
+    @available(iOS 13, *)
     public func clientOnlyStream<
         Input: SwiftProtobuf.Message, Output: SwiftProtobuf.Message
     >(
@@ -199,6 +202,7 @@ extension ProtocolClient: ProtocolClientInterface {
         return bidirectionalAsync.configureForSending(with: callbacks)
     }
 
+    @available(iOS 13, *)
     public func serverOnlyStream<
         Input: SwiftProtobuf.Message, Output: SwiftProtobuf.Message
     >(

--- a/Libraries/Connect/Implementation/Streaming/BidirectionalAsyncStream.swift
+++ b/Libraries/Connect/Implementation/Streaming/BidirectionalAsyncStream.swift
@@ -17,6 +17,7 @@ import SwiftProtobuf
 /// Concrete implementation of `BidirectionalAsyncStreamInterface`.
 /// Provides the necessary wiring to bridge from closures/callbacks to Swift's `AsyncStream`
 /// to work with async/await.
+@available(iOS 13, *)
 final class BidirectionalAsyncStream<Input: SwiftProtobuf.Message, Output: SwiftProtobuf.Message> {
     /// The underlying async stream that will be exposed to the consumer.
     /// Force unwrapped because it captures `self` on `init`.
@@ -81,6 +82,7 @@ final class BidirectionalAsyncStream<Input: SwiftProtobuf.Message, Output: Swift
     }
 }
 
+@available(iOS 13, *)
 extension BidirectionalAsyncStream: BidirectionalAsyncStreamInterface {
     @discardableResult
     func send(_ input: Input) throws -> Self {
@@ -102,4 +104,5 @@ extension BidirectionalAsyncStream: BidirectionalAsyncStreamInterface {
 }
 
 // Conforms to the client-only interface since it matches exactly and the implementation is internal
+@available(iOS 13, *)
 extension BidirectionalAsyncStream: ClientOnlyAsyncStreamInterface {}

--- a/Libraries/Connect/Implementation/Streaming/ServerOnlyAsyncStream.swift
+++ b/Libraries/Connect/Implementation/Streaming/ServerOnlyAsyncStream.swift
@@ -15,6 +15,7 @@
 import SwiftProtobuf
 
 /// Concrete implementation of `ServerOnlyAsyncStreamInterface`.
+@available(iOS 13, *)
 final class ServerOnlyAsyncStream<Input: SwiftProtobuf.Message, Output: SwiftProtobuf.Message> {
     private let bidirectionalStream: BidirectionalAsyncStream<Input, Output>
 
@@ -23,6 +24,7 @@ final class ServerOnlyAsyncStream<Input: SwiftProtobuf.Message, Output: SwiftPro
     }
 }
 
+@available(iOS 13, *)
 extension ServerOnlyAsyncStream: ServerOnlyAsyncStreamInterface {
     func send(_ input: Input) throws {
         try self.bidirectionalStream.send(input)

--- a/Libraries/Connect/Implementation/UnaryAsyncWrapper.swift
+++ b/Libraries/Connect/Implementation/UnaryAsyncWrapper.swift
@@ -20,6 +20,7 @@ import SwiftProtobuf
 /// For discussions on why this is necessary, see:
 /// https://forums.swift.org/t/how-to-use-withtaskcancellationhandler-properly/54341/37
 /// https://stackoverflow.com/q/71898080
+@available(iOS 13, *)
 actor UnaryAsyncWrapper<Output: SwiftProtobuf.Message> {
     private var cancelable: Cancelable?
     private let sendUnary: PerformClosure

--- a/Libraries/Connect/Interfaces/ProtocolClientInterface.swift
+++ b/Libraries/Connect/Interfaces/ProtocolClientInterface.swift
@@ -114,6 +114,7 @@ public protocol ProtocolClientInterface {
     /// - parameter headers: The outbound request headers to include.
     ///
     /// - returns: The response which is returned asynchronously.
+    @available(iOS 13, *)
     func unary<
         Input: SwiftProtobuf.Message, Output: SwiftProtobuf.Message
     >(
@@ -134,6 +135,7 @@ public protocol ProtocolClientInterface {
     /// - parameter headers: The outbound request headers to include.
     ///
     /// - returns: An interface for sending and receiving data over the stream using async/await.
+    @available(iOS 13, *)
     func bidirectionalStream<
         Input: SwiftProtobuf.Message, Output: SwiftProtobuf.Message
     >(
@@ -153,6 +155,7 @@ public protocol ProtocolClientInterface {
     /// - parameter headers: The outbound request headers to include.
     ///
     /// - returns: An interface for sending and receiving data over the stream using async/await.
+    @available(iOS 13, *)
     func clientOnlyStream<
         Input: SwiftProtobuf.Message, Output: SwiftProtobuf.Message
     >(
@@ -172,6 +175,7 @@ public protocol ProtocolClientInterface {
     /// - parameter headers: The outbound request headers to include.
     ///
     /// - returns: An interface for sending and receiving data over the stream using async/await.
+    @available(iOS 13, *)
     func serverOnlyStream<
         Input: SwiftProtobuf.Message, Output: SwiftProtobuf.Message
     >(

--- a/Libraries/Connect/Interfaces/Streams/BidirectionalAsyncStreamInterface.swift
+++ b/Libraries/Connect/Interfaces/Streams/BidirectionalAsyncStreamInterface.swift
@@ -15,6 +15,7 @@
 import SwiftProtobuf
 
 /// Represents a bidirectional stream that can be interacted with using async/await.
+@available(iOS 13, *)
 public protocol BidirectionalAsyncStreamInterface<Input, Output> {
     /// The input (request) message type.
     associatedtype Input: SwiftProtobuf.Message

--- a/Libraries/Connect/Interfaces/Streams/ClientOnlyAsyncStreamInterface.swift
+++ b/Libraries/Connect/Interfaces/Streams/ClientOnlyAsyncStreamInterface.swift
@@ -16,6 +16,7 @@ import SwiftProtobuf
 
 /// Represents a client-only stream (a stream where the client streams data to the server and
 /// eventually receives a response) that can be interacted with using async/await.
+@available(iOS 13, *)
 public protocol ClientOnlyAsyncStreamInterface<Input, Output> {
     /// The input (request) message type.
     associatedtype Input: SwiftProtobuf.Message

--- a/Libraries/Connect/Interfaces/Streams/ServerOnlyAsyncStreamInterface.swift
+++ b/Libraries/Connect/Interfaces/Streams/ServerOnlyAsyncStreamInterface.swift
@@ -16,6 +16,7 @@ import SwiftProtobuf
 
 /// Represents a server-only stream (a stream where the server streams data to the client after
 /// receiving an initial request) that can be interacted with using async/await.
+@available(iOS 13, *)
 public protocol ServerOnlyAsyncStreamInterface<Input, Output> {
     /// The input (request) message type.
     associatedtype Input: SwiftProtobuf.Message

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 let package = Package(
     name: "Connect",
     platforms: [
-        .iOS(.v14),
+        .iOS(.v13),
         .macOS(.v10_15),
     ],
     products: [

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 let package = Package(
     name: "Connect",
     platforms: [
-        .iOS(.v13),
+        .iOS(.v12),
         .macOS(.v10_15),
     ],
     products: [

--- a/Plugins/ConnectMocksPlugin/ConnectMockGenerator.swift
+++ b/Plugins/ConnectMocksPlugin/ConnectMockGenerator.swift
@@ -82,6 +82,7 @@ final class ConnectMockGenerator: Generator {
                     self.printLine(
                         "/// Mocked for async calls to `\(method.name(using: self.options))()`."
                     )
+                    self.printLine("@available(iOS 13, *)")
                     self.printLine(
                         """
                         \(self.propertyVisibility) var \(method.asyncAwaitMockPropertyName()) = \
@@ -143,6 +144,7 @@ final class ConnectMockGenerator: Generator {
     private func printAsyncAwaitMethodMockImplementation(for method: MethodDescriptor) {
         self.printLine()
 
+        self.printLine("@available(iOS 13, *)")
         self.printLine(
             "\(self.typeVisibility) "
             + method.asyncAwaitSignature(

--- a/Plugins/ConnectSwiftPlugin/ConnectClientGenerator.swift
+++ b/Plugins/ConnectSwiftPlugin/ConnectClientGenerator.swift
@@ -131,6 +131,7 @@ final class ConnectClientGenerator: Generator {
     private func printAsyncAwaitMethodInterface(for method: MethodDescriptor) {
         self.printLine()
         self.printCommentsIfNeeded(for: method)
+        self.printLine("@available(iOS 13, *)")
         self.printLine(
             method.asyncAwaitSignature(
                 using: self.namer, includeDefaults: false, options: self.options
@@ -159,6 +160,7 @@ final class ConnectClientGenerator: Generator {
 
     private func printAsyncAwaitMethodImplementation(for method: MethodDescriptor) {
         self.printLine()
+        self.printLine("@available(iOS 13, *)")
         self.printLine(
             "\(self.visibility) "
             + method.asyncAwaitSignature(

--- a/Tests/ConnectLibraryTests/Generated/grpc/testing/test.connect.swift
+++ b/Tests/ConnectLibraryTests/Generated/grpc/testing/test.connect.swift
@@ -16,6 +16,7 @@ internal protocol Grpc_Testing_TestServiceClientInterface {
     func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
 
     /// One empty request followed by one empty response.
+    @available(iOS 13, *)
     func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_Empty>
 
     /// One request followed by one response.
@@ -23,6 +24,7 @@ internal protocol Grpc_Testing_TestServiceClientInterface {
     func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable
 
     /// One request followed by one response.
+    @available(iOS 13, *)
     func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_SimpleResponse>
 
     /// One request followed by one response. This RPC always fails.
@@ -30,6 +32,7 @@ internal protocol Grpc_Testing_TestServiceClientInterface {
     func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable
 
     /// One request followed by one response. This RPC always fails.
+    @available(iOS 13, *)
     func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_SimpleResponse>
 
     /// One request followed by one response. Response has cache control
@@ -41,6 +44,7 @@ internal protocol Grpc_Testing_TestServiceClientInterface {
     /// One request followed by one response. Response has cache control
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
+    @available(iOS 13, *)
     func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_SimpleResponse>
 
     /// One request followed by a sequence of responses (streamed download).
@@ -49,12 +53,14 @@ internal protocol Grpc_Testing_TestServiceClientInterface {
 
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
+    @available(iOS 13, *)
     func `streamingOutputCall`(headers: Connect.Headers) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
 
     /// One request followed by a sequence of responses (streamed download). This RPC always fails.
     func `failStreamingOutputCall`(headers: Connect.Headers, onResult: @escaping (Connect.StreamResult<Grpc_Testing_StreamingOutputCallResponse>) -> Void) -> any Connect.ServerOnlyStreamInterface<Grpc_Testing_StreamingOutputCallRequest>
 
     /// One request followed by a sequence of responses (streamed download). This RPC always fails.
+    @available(iOS 13, *)
     func `failStreamingOutputCall`(headers: Connect.Headers) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
 
     /// A sequence of requests followed by one response (streamed upload).
@@ -63,6 +69,7 @@ internal protocol Grpc_Testing_TestServiceClientInterface {
 
     /// A sequence of requests followed by one response (streamed upload).
     /// The server returns the aggregated size of client payload as the result.
+    @available(iOS 13, *)
     func `streamingInputCall`(headers: Connect.Headers) -> any Connect.ClientOnlyAsyncStreamInterface<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse>
 
     /// A sequence of requests with each request served by the server immediately.
@@ -73,6 +80,7 @@ internal protocol Grpc_Testing_TestServiceClientInterface {
     /// A sequence of requests with each request served by the server immediately.
     /// As one request could lead to multiple responses, this interface
     /// demonstrates the idea of full duplexing.
+    @available(iOS 13, *)
     func `fullDuplexCall`(headers: Connect.Headers) -> any Connect.BidirectionalAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
 
     /// A sequence of requests followed by a sequence of responses.
@@ -85,6 +93,7 @@ internal protocol Grpc_Testing_TestServiceClientInterface {
     /// The server buffers all the client requests and then serves them in order. A
     /// stream of responses are returned to the client when the server starts with
     /// first request.
+    @available(iOS 13, *)
     func `halfDuplexCall`(headers: Connect.Headers) -> any Connect.BidirectionalAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>
 
     /// The test server will not implement this method. It will be used
@@ -94,6 +103,7 @@ internal protocol Grpc_Testing_TestServiceClientInterface {
 
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
+    @available(iOS 13, *)
     func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_Empty>
 
     /// The test server will not implement this method. It will be used
@@ -102,6 +112,7 @@ internal protocol Grpc_Testing_TestServiceClientInterface {
 
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented streaming output methods.
+    @available(iOS 13, *)
     func `unimplementedStreamingOutputCall`(headers: Connect.Headers) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_Empty, Grpc_Testing_Empty>
 }
 
@@ -118,6 +129,7 @@ internal final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceCli
         return self.client.unary(path: "grpc.testing.TestService/EmptyCall", request: request, headers: headers, completion: completion)
     }
 
+    @available(iOS 13, *)
     internal func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
         return await self.client.unary(path: "grpc.testing.TestService/EmptyCall", request: request, headers: headers)
     }
@@ -127,6 +139,7 @@ internal final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceCli
         return self.client.unary(path: "grpc.testing.TestService/UnaryCall", request: request, headers: headers, completion: completion)
     }
 
+    @available(iOS 13, *)
     internal func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
         return await self.client.unary(path: "grpc.testing.TestService/UnaryCall", request: request, headers: headers)
     }
@@ -136,6 +149,7 @@ internal final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceCli
         return self.client.unary(path: "grpc.testing.TestService/FailUnaryCall", request: request, headers: headers, completion: completion)
     }
 
+    @available(iOS 13, *)
     internal func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
         return await self.client.unary(path: "grpc.testing.TestService/FailUnaryCall", request: request, headers: headers)
     }
@@ -145,6 +159,7 @@ internal final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceCli
         return self.client.unary(path: "grpc.testing.TestService/CacheableUnaryCall", request: request, headers: headers, completion: completion)
     }
 
+    @available(iOS 13, *)
     internal func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
         return await self.client.unary(path: "grpc.testing.TestService/CacheableUnaryCall", request: request, headers: headers)
     }
@@ -153,6 +168,7 @@ internal final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceCli
         return self.client.serverOnlyStream(path: "grpc.testing.TestService/StreamingOutputCall", headers: headers, onResult: onResult)
     }
 
+    @available(iOS 13, *)
     internal func `streamingOutputCall`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
         return self.client.serverOnlyStream(path: "grpc.testing.TestService/StreamingOutputCall", headers: headers)
     }
@@ -161,6 +177,7 @@ internal final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceCli
         return self.client.serverOnlyStream(path: "grpc.testing.TestService/FailStreamingOutputCall", headers: headers, onResult: onResult)
     }
 
+    @available(iOS 13, *)
     internal func `failStreamingOutputCall`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
         return self.client.serverOnlyStream(path: "grpc.testing.TestService/FailStreamingOutputCall", headers: headers)
     }
@@ -169,6 +186,7 @@ internal final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceCli
         return self.client.clientOnlyStream(path: "grpc.testing.TestService/StreamingInputCall", headers: headers, onResult: onResult)
     }
 
+    @available(iOS 13, *)
     internal func `streamingInputCall`(headers: Connect.Headers = [:]) -> any Connect.ClientOnlyAsyncStreamInterface<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse> {
         return self.client.clientOnlyStream(path: "grpc.testing.TestService/StreamingInputCall", headers: headers)
     }
@@ -177,6 +195,7 @@ internal final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceCli
         return self.client.bidirectionalStream(path: "grpc.testing.TestService/FullDuplexCall", headers: headers, onResult: onResult)
     }
 
+    @available(iOS 13, *)
     internal func `fullDuplexCall`(headers: Connect.Headers = [:]) -> any Connect.BidirectionalAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
         return self.client.bidirectionalStream(path: "grpc.testing.TestService/FullDuplexCall", headers: headers)
     }
@@ -185,6 +204,7 @@ internal final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceCli
         return self.client.bidirectionalStream(path: "grpc.testing.TestService/HalfDuplexCall", headers: headers, onResult: onResult)
     }
 
+    @available(iOS 13, *)
     internal func `halfDuplexCall`(headers: Connect.Headers = [:]) -> any Connect.BidirectionalAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
         return self.client.bidirectionalStream(path: "grpc.testing.TestService/HalfDuplexCall", headers: headers)
     }
@@ -194,6 +214,7 @@ internal final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceCli
         return self.client.unary(path: "grpc.testing.TestService/UnimplementedCall", request: request, headers: headers, completion: completion)
     }
 
+    @available(iOS 13, *)
     internal func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
         return await self.client.unary(path: "grpc.testing.TestService/UnimplementedCall", request: request, headers: headers)
     }
@@ -202,6 +223,7 @@ internal final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceCli
         return self.client.serverOnlyStream(path: "grpc.testing.TestService/UnimplementedStreamingOutputCall", headers: headers, onResult: onResult)
     }
 
+    @available(iOS 13, *)
     internal func `unimplementedStreamingOutputCall`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_Empty, Grpc_Testing_Empty> {
         return self.client.serverOnlyStream(path: "grpc.testing.TestService/UnimplementedStreamingOutputCall", headers: headers)
     }
@@ -232,12 +254,14 @@ internal protocol Grpc_Testing_UnimplementedServiceClientInterface {
     func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
 
     /// A call that no server should implement
+    @available(iOS 13, *)
     func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_Empty>
 
     /// A call that no server should implement
     func `unimplementedStreamingOutputCall`(headers: Connect.Headers, onResult: @escaping (Connect.StreamResult<Grpc_Testing_Empty>) -> Void) -> any Connect.ServerOnlyStreamInterface<Grpc_Testing_Empty>
 
     /// A call that no server should implement
+    @available(iOS 13, *)
     func `unimplementedStreamingOutputCall`(headers: Connect.Headers) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_Empty, Grpc_Testing_Empty>
 }
 
@@ -254,6 +278,7 @@ internal final class Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimp
         return self.client.unary(path: "grpc.testing.UnimplementedService/UnimplementedCall", request: request, headers: headers, completion: completion)
     }
 
+    @available(iOS 13, *)
     internal func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
         return await self.client.unary(path: "grpc.testing.UnimplementedService/UnimplementedCall", request: request, headers: headers)
     }
@@ -262,6 +287,7 @@ internal final class Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimp
         return self.client.serverOnlyStream(path: "grpc.testing.UnimplementedService/UnimplementedStreamingOutputCall", headers: headers, onResult: onResult)
     }
 
+    @available(iOS 13, *)
     internal func `unimplementedStreamingOutputCall`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_Empty, Grpc_Testing_Empty> {
         return self.client.serverOnlyStream(path: "grpc.testing.UnimplementedService/UnimplementedStreamingOutputCall", headers: headers)
     }
@@ -280,11 +306,13 @@ internal protocol Grpc_Testing_ReconnectServiceClientInterface {
     @discardableResult
     func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
 
+    @available(iOS 13, *)
     func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_Empty>
 
     @discardableResult
     func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_ReconnectInfo>) -> Void) -> Connect.Cancelable
 
+    @available(iOS 13, *)
     func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_ReconnectInfo>
 }
 
@@ -301,6 +329,7 @@ internal final class Grpc_Testing_ReconnectServiceClient: Grpc_Testing_Reconnect
         return self.client.unary(path: "grpc.testing.ReconnectService/Start", request: request, headers: headers, completion: completion)
     }
 
+    @available(iOS 13, *)
     internal func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
         return await self.client.unary(path: "grpc.testing.ReconnectService/Start", request: request, headers: headers)
     }
@@ -310,6 +339,7 @@ internal final class Grpc_Testing_ReconnectServiceClient: Grpc_Testing_Reconnect
         return self.client.unary(path: "grpc.testing.ReconnectService/Stop", request: request, headers: headers, completion: completion)
     }
 
+    @available(iOS 13, *)
     internal func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_ReconnectInfo> {
         return await self.client.unary(path: "grpc.testing.ReconnectService/Stop", request: request, headers: headers)
     }
@@ -330,6 +360,7 @@ internal protocol Grpc_Testing_LoadBalancerStatsServiceClientInterface {
     func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>) -> Void) -> Connect.Cancelable
 
     /// Gets the backend distribution for RPCs sent by a test client.
+    @available(iOS 13, *)
     func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>
 
     /// Gets the accumulated stats for RPCs sent by a test client.
@@ -337,6 +368,7 @@ internal protocol Grpc_Testing_LoadBalancerStatsServiceClientInterface {
     func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>) -> Void) -> Connect.Cancelable
 
     /// Gets the accumulated stats for RPCs sent by a test client.
+    @available(iOS 13, *)
     func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>
 }
 
@@ -353,6 +385,7 @@ internal final class Grpc_Testing_LoadBalancerStatsServiceClient: Grpc_Testing_L
         return self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientStats", request: request, headers: headers, completion: completion)
     }
 
+    @available(iOS 13, *)
     internal func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse> {
         return await self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientStats", request: request, headers: headers)
     }
@@ -362,6 +395,7 @@ internal final class Grpc_Testing_LoadBalancerStatsServiceClient: Grpc_Testing_L
         return self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats", request: request, headers: headers, completion: completion)
     }
 
+    @available(iOS 13, *)
     internal func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse> {
         return await self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats", request: request, headers: headers)
     }
@@ -380,11 +414,13 @@ internal protocol Grpc_Testing_XdsUpdateHealthServiceClientInterface {
     @discardableResult
     func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
 
+    @available(iOS 13, *)
     func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_Empty>
 
     @discardableResult
     func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable
 
+    @available(iOS 13, *)
     func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_Empty>
 }
 
@@ -401,6 +437,7 @@ internal final class Grpc_Testing_XdsUpdateHealthServiceClient: Grpc_Testing_Xds
         return self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetServing", request: request, headers: headers, completion: completion)
     }
 
+    @available(iOS 13, *)
     internal func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
         return await self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetServing", request: request, headers: headers)
     }
@@ -410,6 +447,7 @@ internal final class Grpc_Testing_XdsUpdateHealthServiceClient: Grpc_Testing_Xds
         return self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetNotServing", request: request, headers: headers, completion: completion)
     }
 
+    @available(iOS 13, *)
     internal func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
         return await self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetNotServing", request: request, headers: headers)
     }
@@ -430,6 +468,7 @@ internal protocol Grpc_Testing_XdsUpdateClientConfigureServiceClientInterface {
     func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers, completion: @escaping (ResponseMessage<Grpc_Testing_ClientConfigureResponse>) -> Void) -> Connect.Cancelable
 
     /// Update the tes client's configuration.
+    @available(iOS 13, *)
     func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers) async -> ResponseMessage<Grpc_Testing_ClientConfigureResponse>
 }
 
@@ -446,6 +485,7 @@ internal final class Grpc_Testing_XdsUpdateClientConfigureServiceClient: Grpc_Te
         return self.client.unary(path: "grpc.testing.XdsUpdateClientConfigureService/Configure", request: request, headers: headers, completion: completion)
     }
 
+    @available(iOS 13, *)
     internal func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_ClientConfigureResponse> {
         return await self.client.unary(path: "grpc.testing.XdsUpdateClientConfigureService/Configure", request: request, headers: headers)
     }

--- a/Tests/ConnectLibraryTests/Generated/grpc/testing/test.mock.swift
+++ b/Tests/ConnectLibraryTests/Generated/grpc/testing/test.mock.swift
@@ -21,46 +21,57 @@ internal class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClien
     /// Mocked for calls to `emptyCall()`.
     internal var mockEmptyCall = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(result: .success(.init())) }
     /// Mocked for async calls to `emptyCall()`.
+    @available(iOS 13, *)
     internal var mockAsyncEmptyCall = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(result: .success(.init())) }
     /// Mocked for calls to `unaryCall()`.
     internal var mockUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> ResponseMessage<Grpc_Testing_SimpleResponse> in .init(result: .success(.init())) }
     /// Mocked for async calls to `unaryCall()`.
+    @available(iOS 13, *)
     internal var mockAsyncUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> ResponseMessage<Grpc_Testing_SimpleResponse> in .init(result: .success(.init())) }
     /// Mocked for calls to `failUnaryCall()`.
     internal var mockFailUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> ResponseMessage<Grpc_Testing_SimpleResponse> in .init(result: .success(.init())) }
     /// Mocked for async calls to `failUnaryCall()`.
+    @available(iOS 13, *)
     internal var mockAsyncFailUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> ResponseMessage<Grpc_Testing_SimpleResponse> in .init(result: .success(.init())) }
     /// Mocked for calls to `cacheableUnaryCall()`.
     internal var mockCacheableUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> ResponseMessage<Grpc_Testing_SimpleResponse> in .init(result: .success(.init())) }
     /// Mocked for async calls to `cacheableUnaryCall()`.
+    @available(iOS 13, *)
     internal var mockAsyncCacheableUnaryCall = { (_: Grpc_Testing_SimpleRequest) -> ResponseMessage<Grpc_Testing_SimpleResponse> in .init(result: .success(.init())) }
     /// Mocked for calls to `streamingOutputCall()`.
     internal var mockStreamingOutputCall = MockServerOnlyStream<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>()
     /// Mocked for async calls to `streamingOutputCall()`.
+    @available(iOS 13, *)
     internal var mockAsyncStreamingOutputCall = MockServerOnlyAsyncStream<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>()
     /// Mocked for calls to `failStreamingOutputCall()`.
     internal var mockFailStreamingOutputCall = MockServerOnlyStream<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>()
     /// Mocked for async calls to `failStreamingOutputCall()`.
+    @available(iOS 13, *)
     internal var mockAsyncFailStreamingOutputCall = MockServerOnlyAsyncStream<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>()
     /// Mocked for calls to `streamingInputCall()`.
     internal var mockStreamingInputCall = MockClientOnlyStream<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse>()
     /// Mocked for async calls to `streamingInputCall()`.
+    @available(iOS 13, *)
     internal var mockAsyncStreamingInputCall = MockClientOnlyAsyncStream<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse>()
     /// Mocked for calls to `fullDuplexCall()`.
     internal var mockFullDuplexCall = MockBidirectionalStream<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>()
     /// Mocked for async calls to `fullDuplexCall()`.
+    @available(iOS 13, *)
     internal var mockAsyncFullDuplexCall = MockBidirectionalAsyncStream<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>()
     /// Mocked for calls to `halfDuplexCall()`.
     internal var mockHalfDuplexCall = MockBidirectionalStream<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>()
     /// Mocked for async calls to `halfDuplexCall()`.
+    @available(iOS 13, *)
     internal var mockAsyncHalfDuplexCall = MockBidirectionalAsyncStream<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse>()
     /// Mocked for calls to `unimplementedCall()`.
     internal var mockUnimplementedCall = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(result: .success(.init())) }
     /// Mocked for async calls to `unimplementedCall()`.
+    @available(iOS 13, *)
     internal var mockAsyncUnimplementedCall = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(result: .success(.init())) }
     /// Mocked for calls to `unimplementedStreamingOutputCall()`.
     internal var mockUnimplementedStreamingOutputCall = MockServerOnlyStream<Grpc_Testing_Empty, Grpc_Testing_Empty>()
     /// Mocked for async calls to `unimplementedStreamingOutputCall()`.
+    @available(iOS 13, *)
     internal var mockAsyncUnimplementedStreamingOutputCall = MockServerOnlyAsyncStream<Grpc_Testing_Empty, Grpc_Testing_Empty>()
 
     internal init() {}
@@ -71,6 +82,7 @@ internal class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClien
         return Connect.Cancelable {}
     }
 
+    @available(iOS 13, *)
     internal func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
         return self.mockAsyncEmptyCall(request)
     }
@@ -81,6 +93,7 @@ internal class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClien
         return Connect.Cancelable {}
     }
 
+    @available(iOS 13, *)
     internal func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
         return self.mockAsyncUnaryCall(request)
     }
@@ -91,6 +104,7 @@ internal class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClien
         return Connect.Cancelable {}
     }
 
+    @available(iOS 13, *)
     internal func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
         return self.mockAsyncFailUnaryCall(request)
     }
@@ -101,6 +115,7 @@ internal class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClien
         return Connect.Cancelable {}
     }
 
+    @available(iOS 13, *)
     internal func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
         return self.mockAsyncCacheableUnaryCall(request)
     }
@@ -110,6 +125,7 @@ internal class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClien
         return self.mockStreamingOutputCall
     }
 
+    @available(iOS 13, *)
     internal func `streamingOutputCall`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
         return self.mockAsyncStreamingOutputCall
     }
@@ -119,6 +135,7 @@ internal class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClien
         return self.mockFailStreamingOutputCall
     }
 
+    @available(iOS 13, *)
     internal func `failStreamingOutputCall`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
         return self.mockAsyncFailStreamingOutputCall
     }
@@ -128,6 +145,7 @@ internal class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClien
         return self.mockStreamingInputCall
     }
 
+    @available(iOS 13, *)
     internal func `streamingInputCall`(headers: Connect.Headers = [:]) -> any Connect.ClientOnlyAsyncStreamInterface<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse> {
         return self.mockAsyncStreamingInputCall
     }
@@ -137,6 +155,7 @@ internal class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClien
         return self.mockFullDuplexCall
     }
 
+    @available(iOS 13, *)
     internal func `fullDuplexCall`(headers: Connect.Headers = [:]) -> any Connect.BidirectionalAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
         return self.mockAsyncFullDuplexCall
     }
@@ -146,6 +165,7 @@ internal class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClien
         return self.mockHalfDuplexCall
     }
 
+    @available(iOS 13, *)
     internal func `halfDuplexCall`(headers: Connect.Headers = [:]) -> any Connect.BidirectionalAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
         return self.mockAsyncHalfDuplexCall
     }
@@ -156,6 +176,7 @@ internal class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClien
         return Connect.Cancelable {}
     }
 
+    @available(iOS 13, *)
     internal func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
         return self.mockAsyncUnimplementedCall(request)
     }
@@ -165,6 +186,7 @@ internal class Grpc_Testing_TestServiceClientMock: Grpc_Testing_TestServiceClien
         return self.mockUnimplementedStreamingOutputCall
     }
 
+    @available(iOS 13, *)
     internal func `unimplementedStreamingOutputCall`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_Empty, Grpc_Testing_Empty> {
         return self.mockAsyncUnimplementedStreamingOutputCall
     }
@@ -182,10 +204,12 @@ internal class Grpc_Testing_UnimplementedServiceClientMock: Grpc_Testing_Unimple
     /// Mocked for calls to `unimplementedCall()`.
     internal var mockUnimplementedCall = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(result: .success(.init())) }
     /// Mocked for async calls to `unimplementedCall()`.
+    @available(iOS 13, *)
     internal var mockAsyncUnimplementedCall = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(result: .success(.init())) }
     /// Mocked for calls to `unimplementedStreamingOutputCall()`.
     internal var mockUnimplementedStreamingOutputCall = MockServerOnlyStream<Grpc_Testing_Empty, Grpc_Testing_Empty>()
     /// Mocked for async calls to `unimplementedStreamingOutputCall()`.
+    @available(iOS 13, *)
     internal var mockAsyncUnimplementedStreamingOutputCall = MockServerOnlyAsyncStream<Grpc_Testing_Empty, Grpc_Testing_Empty>()
 
     internal init() {}
@@ -196,6 +220,7 @@ internal class Grpc_Testing_UnimplementedServiceClientMock: Grpc_Testing_Unimple
         return Connect.Cancelable {}
     }
 
+    @available(iOS 13, *)
     internal func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
         return self.mockAsyncUnimplementedCall(request)
     }
@@ -205,6 +230,7 @@ internal class Grpc_Testing_UnimplementedServiceClientMock: Grpc_Testing_Unimple
         return self.mockUnimplementedStreamingOutputCall
     }
 
+    @available(iOS 13, *)
     internal func `unimplementedStreamingOutputCall`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_Empty, Grpc_Testing_Empty> {
         return self.mockAsyncUnimplementedStreamingOutputCall
     }
@@ -222,10 +248,12 @@ internal class Grpc_Testing_ReconnectServiceClientMock: Grpc_Testing_ReconnectSe
     /// Mocked for calls to `start()`.
     internal var mockStart = { (_: Grpc_Testing_ReconnectParams) -> ResponseMessage<Grpc_Testing_Empty> in .init(result: .success(.init())) }
     /// Mocked for async calls to `start()`.
+    @available(iOS 13, *)
     internal var mockAsyncStart = { (_: Grpc_Testing_ReconnectParams) -> ResponseMessage<Grpc_Testing_Empty> in .init(result: .success(.init())) }
     /// Mocked for calls to `stop()`.
     internal var mockStop = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_ReconnectInfo> in .init(result: .success(.init())) }
     /// Mocked for async calls to `stop()`.
+    @available(iOS 13, *)
     internal var mockAsyncStop = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_ReconnectInfo> in .init(result: .success(.init())) }
 
     internal init() {}
@@ -236,6 +264,7 @@ internal class Grpc_Testing_ReconnectServiceClientMock: Grpc_Testing_ReconnectSe
         return Connect.Cancelable {}
     }
 
+    @available(iOS 13, *)
     internal func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
         return self.mockAsyncStart(request)
     }
@@ -246,6 +275,7 @@ internal class Grpc_Testing_ReconnectServiceClientMock: Grpc_Testing_ReconnectSe
         return Connect.Cancelable {}
     }
 
+    @available(iOS 13, *)
     internal func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_ReconnectInfo> {
         return self.mockAsyncStop(request)
     }
@@ -263,10 +293,12 @@ internal class Grpc_Testing_LoadBalancerStatsServiceClientMock: Grpc_Testing_Loa
     /// Mocked for calls to `getClientStats()`.
     internal var mockGetClientStats = { (_: Grpc_Testing_LoadBalancerStatsRequest) -> ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse> in .init(result: .success(.init())) }
     /// Mocked for async calls to `getClientStats()`.
+    @available(iOS 13, *)
     internal var mockAsyncGetClientStats = { (_: Grpc_Testing_LoadBalancerStatsRequest) -> ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse> in .init(result: .success(.init())) }
     /// Mocked for calls to `getClientAccumulatedStats()`.
     internal var mockGetClientAccumulatedStats = { (_: Grpc_Testing_LoadBalancerAccumulatedStatsRequest) -> ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse> in .init(result: .success(.init())) }
     /// Mocked for async calls to `getClientAccumulatedStats()`.
+    @available(iOS 13, *)
     internal var mockAsyncGetClientAccumulatedStats = { (_: Grpc_Testing_LoadBalancerAccumulatedStatsRequest) -> ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse> in .init(result: .success(.init())) }
 
     internal init() {}
@@ -277,6 +309,7 @@ internal class Grpc_Testing_LoadBalancerStatsServiceClientMock: Grpc_Testing_Loa
         return Connect.Cancelable {}
     }
 
+    @available(iOS 13, *)
     internal func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse> {
         return self.mockAsyncGetClientStats(request)
     }
@@ -287,6 +320,7 @@ internal class Grpc_Testing_LoadBalancerStatsServiceClientMock: Grpc_Testing_Loa
         return Connect.Cancelable {}
     }
 
+    @available(iOS 13, *)
     internal func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse> {
         return self.mockAsyncGetClientAccumulatedStats(request)
     }
@@ -304,10 +338,12 @@ internal class Grpc_Testing_XdsUpdateHealthServiceClientMock: Grpc_Testing_XdsUp
     /// Mocked for calls to `setServing()`.
     internal var mockSetServing = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(result: .success(.init())) }
     /// Mocked for async calls to `setServing()`.
+    @available(iOS 13, *)
     internal var mockAsyncSetServing = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(result: .success(.init())) }
     /// Mocked for calls to `setNotServing()`.
     internal var mockSetNotServing = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(result: .success(.init())) }
     /// Mocked for async calls to `setNotServing()`.
+    @available(iOS 13, *)
     internal var mockAsyncSetNotServing = { (_: Grpc_Testing_Empty) -> ResponseMessage<Grpc_Testing_Empty> in .init(result: .success(.init())) }
 
     internal init() {}
@@ -318,6 +354,7 @@ internal class Grpc_Testing_XdsUpdateHealthServiceClientMock: Grpc_Testing_XdsUp
         return Connect.Cancelable {}
     }
 
+    @available(iOS 13, *)
     internal func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
         return self.mockAsyncSetServing(request)
     }
@@ -328,6 +365,7 @@ internal class Grpc_Testing_XdsUpdateHealthServiceClientMock: Grpc_Testing_XdsUp
         return Connect.Cancelable {}
     }
 
+    @available(iOS 13, *)
     internal func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
         return self.mockAsyncSetNotServing(request)
     }
@@ -345,6 +383,7 @@ internal class Grpc_Testing_XdsUpdateClientConfigureServiceClientMock: Grpc_Test
     /// Mocked for calls to `configure()`.
     internal var mockConfigure = { (_: Grpc_Testing_ClientConfigureRequest) -> ResponseMessage<Grpc_Testing_ClientConfigureResponse> in .init(result: .success(.init())) }
     /// Mocked for async calls to `configure()`.
+    @available(iOS 13, *)
     internal var mockAsyncConfigure = { (_: Grpc_Testing_ClientConfigureRequest) -> ResponseMessage<Grpc_Testing_ClientConfigureResponse> in .init(result: .success(.init())) }
 
     internal init() {}
@@ -355,6 +394,7 @@ internal class Grpc_Testing_XdsUpdateClientConfigureServiceClientMock: Grpc_Test
         return Connect.Cancelable {}
     }
 
+    @available(iOS 13, *)
     internal func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_ClientConfigureResponse> {
         return self.mockAsyncConfigure(request)
     }


### PR DESCRIPTION
The necessary async/await APIs are only available on iOS 13+, so code generated using the `GenerateAsyncMethods=true` option will be unavailable on iOS 12.