### PR TITLE
Rename `streamResultFunc` to `streamResultFunction`

### DIFF
--- a/Libraries/Connect/Implementation/Interceptors/ConnectInterceptor.swift
+++ b/Libraries/Connect/Implementation/Interceptors/ConnectInterceptor.swift
@@ -118,7 +118,7 @@ extension ConnectInterceptor: Interceptor {
             requestDataFunction: { data in
                 return Envelope.packMessage(data, using: self.config.requestCompression)
             },
-            streamResultFunc: { result in
+            streamResultFunction: { result in
                 switch result {
                 case .headers(let headers):
                     responseHeaders = headers

--- a/Libraries/Connect/Implementation/Interceptors/GRPCWebInterceptor.swift
+++ b/Libraries/Connect/Implementation/Interceptors/GRPCWebInterceptor.swift
@@ -123,7 +123,7 @@ extension GRPCWebInterceptor: Interceptor {
             requestDataFunction: { data in
                 return Envelope.packMessage(data, using: self.config.requestCompression)
             },
-            streamResultFunc: { result in
+            streamResultFunction: { result in
                 switch result {
                 case .headers(let headers):
                     if let grpcCode = headers.grpcStatus() {

--- a/Libraries/Connect/Implementation/Interceptors/InterceptorChain.swift
+++ b/Libraries/Connect/Implementation/Interceptors/InterceptorChain.swift
@@ -69,9 +69,9 @@ struct InterceptorChain {
             requestDataFunction: { data in
                 return executeInterceptors(interceptors.map(\.requestDataFunction), initial: data)
             },
-            streamResultFunc: { result in
+            streamResultFunction: { result in
                 return executeInterceptors(
-                    interceptors.reversed().map(\.streamResultFunc),
+                    interceptors.reversed().map(\.streamResultFunction),
                     initial: result
                 )
             }

--- a/Libraries/Connect/Implementation/ProtocolClient.swift
+++ b/Libraries/Connect/Implementation/ProtocolClient.swift
@@ -237,7 +237,7 @@ extension ProtocolClient: ProtocolClientInterface {
 
         let interceptAndHandleResult: (StreamResult<Data>) -> Void = { streamResult in
             do {
-                let interceptedResult = chain.streamResultFunc(streamResult)
+                let interceptedResult = chain.streamResultFunction(streamResult)
                 onResult(try interceptedResult.toTypedResult(using: codec))
             } catch let error {
                 // TODO: Should we terminate the stream here?

--- a/Libraries/Connect/Interfaces/Interceptor.swift
+++ b/Libraries/Connect/Interfaces/Interceptor.swift
@@ -53,15 +53,15 @@ public struct UnaryFunction {
 public struct StreamFunction {
     public let requestFunction: (HTTPRequest) -> HTTPRequest
     public let requestDataFunction: (Data) -> Data
-    public let streamResultFunc: (StreamResult<Data>) -> StreamResult<Data>
+    public let streamResultFunction: (StreamResult<Data>) -> StreamResult<Data>
 
     public init(
         requestFunction: @escaping (HTTPRequest) -> HTTPRequest,
         requestDataFunction: @escaping (Data) -> Data,
-        streamResultFunc: @escaping (StreamResult<Data>) -> StreamResult<Data>
+        streamResultFunction: @escaping (StreamResult<Data>) -> StreamResult<Data>
     ) {
         self.requestFunction = requestFunction
         self.requestDataFunction = requestDataFunction
-        self.streamResultFunc = streamResultFunc
+        self.streamResultFunction = streamResultFunction
     }
 }

--- a/Tests/ConnectLibraryTests/ConnectTests/InterceptorChainTests.swift
+++ b/Tests/ConnectLibraryTests/ConnectTests/InterceptorChainTests.swift
@@ -83,7 +83,7 @@ private struct MockStreamInterceptor: Interceptor {
                 self.requestDataExpectation.fulfill()
                 return self.outboundMessageData
             },
-            streamResultFunc: { result in
+            streamResultFunction: { result in
                 self.resultExpectation.fulfill()
                 switch result {
                 case .headers(let headers):
@@ -208,21 +208,21 @@ final class InterceptorChainTests: XCTestCase {
         let interceptedRequestData = chain.requestDataFunction(Data())
         XCTAssertEqual(interceptedRequestData, filterBData)
 
-        switch chain.streamResultFunc(.headers(Headers())) {
+        switch chain.streamResultFunction(.headers(Headers())) {
         case .headers(let interceptedResultHeaders):
             XCTAssertEqual(interceptedResultHeaders["filter-chain"], ["filter-b", "filter-a"])
         case .message, .complete:
             XCTFail("Unexpected result")
         }
 
-        switch chain.streamResultFunc(.message(Data())) {
+        switch chain.streamResultFunction(.message(Data())) {
         case .message(let interceptedData):
             XCTAssertEqual(interceptedData, filterAData)
         case .headers, .complete:
             XCTFail("Unexpected result")
         }
 
-        switch chain.streamResultFunc(.complete(code: .ok, error: nil, trailers: nil)) {
+        switch chain.streamResultFunction(.complete(code: .ok, error: nil, trailers: nil)) {
         case .complete(_, _, let interceptedTrailers):
             XCTAssertEqual(interceptedTrailers?["filter-chain"], ["filter-b", "filter-a"])
         case .headers, .message:

--- a/Tests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
+++ b/Tests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
@@ -25,7 +25,7 @@ private struct NoopInterceptor: Interceptor {
         return .init(
             requestFunction: { $0 },
             requestDataFunction: { $0 },
-            streamResultFunc: { $0 }
+            streamResultFunction: { $0 }
         )
     }
 


### PR DESCRIPTION
This more closely resembles the related closures' names.