### PR TITLE
Add `HTTPMetrics` to unary interceptors

### DIFF
--- a/Libraries/Connect/Implementation/Interceptors/ConnectInterceptor.swift
+++ b/Libraries/Connect/Implementation/Interceptors/ConnectInterceptor.swift
@@ -94,7 +94,8 @@ extension ConnectInterceptor: Interceptor {
                         tracingInfo: response.tracingInfo
                     )
                 }
-            }
+            },
+            responseMetricsFunction: { $0 }
         )
     }
 

--- a/Libraries/Connect/Implementation/Interceptors/GRPCWebInterceptor.swift
+++ b/Libraries/Connect/Implementation/Interceptors/GRPCWebInterceptor.swift
@@ -104,7 +104,8 @@ extension GRPCWebInterceptor: Interceptor {
                         tracingInfo: response.tracingInfo
                     )
                 }
-            }
+            },
+            responseMetricsFunction: { $0 }
         )
     }
 

--- a/Libraries/Connect/Implementation/Interceptors/InterceptorChain.swift
+++ b/Libraries/Connect/Implementation/Interceptors/InterceptorChain.swift
@@ -48,6 +48,12 @@ struct InterceptorChain {
                     interceptors.reversed().map(\.responseFunction),
                     initial: response
                 )
+            },
+            responseMetricsFunction: { metrics in
+                return executeInterceptors(
+                    interceptors.reversed().map(\.responseMetricsFunction),
+                    initial: metrics
+                )
             }
         )
     }

--- a/Libraries/Connect/Implementation/ProtocolClient.swift
+++ b/Libraries/Connect/Implementation/ProtocolClient.swift
@@ -69,7 +69,10 @@ extension ProtocolClient: ProtocolClientInterface {
             headers: headers,
             message: data
         ))
-        return self.httpClient.unary(request: request) { response in
+        return self.httpClient.unary(
+            request: request,
+            onMetrics: { _ = chain.responseMetricsFunction($0) }
+        ) { response in
             let response = chain.responseFunction(response)
             let responseMessage: ResponseMessage<Output>
             if response.code != .ok {

--- a/Libraries/Connect/Implementation/ProtocolClient.swift
+++ b/Libraries/Connect/Implementation/ProtocolClient.swift
@@ -71,7 +71,10 @@ extension ProtocolClient: ProtocolClientInterface {
         ))
         return self.httpClient.unary(
             request: request,
-            onMetrics: { _ = chain.responseMetricsFunction($0) },
+            onMetrics: { metrics in
+                // Response is unused, but metrics are passed to interceptors
+                _ = chain.responseMetricsFunction(metrics)
+            },
             onResponse: { response in
                 let response = chain.responseFunction(response)
                 let responseMessage: ResponseMessage<Output>

--- a/Libraries/Connect/Implementation/ProtocolClient.swift
+++ b/Libraries/Connect/Implementation/ProtocolClient.swift
@@ -117,7 +117,8 @@ extension ProtocolClient: ProtocolClientInterface {
                     )
                 }
                 completion(responseMessage)
-        })
+            }
+        )
     }
 
     public func bidirectionalStream<

--- a/Libraries/Connect/Interfaces/HTTPClientInterface.swift
+++ b/Libraries/Connect/Interfaces/HTTPClientInterface.swift
@@ -17,12 +17,17 @@ public protocol HTTPClientInterface {
     /// Perform a unary HTTP request.
     ///
     /// - parameter request: The outbound request headers and data.
-    /// - parameter completion: Closure that should be called upon completion of the request.
+    /// - parameter onMetrics: Closure that should be called when metrics are finalized. This may be
+    ///                        called before or after `onResponse`.
+    /// - parameter onResponse: Closure that should be called when a response is received.
     ///
     /// - returns: A type which can be used to cancel the outbound request.
     @discardableResult
-    func unary(request: HTTPRequest, completion: @Sendable @escaping (HTTPResponse) -> Void)
-        -> Cancelable
+    func unary(
+        request: HTTPRequest,
+        onMetrics: @Sendable @escaping (HTTPMetrics) -> Void,
+        onResponse: @Sendable @escaping (HTTPResponse) -> Void
+    ) -> Cancelable
 
     /// Initialize a new HTTP stream.
     ///

--- a/Libraries/Connect/Interfaces/HTTPMetrics.swift
+++ b/Libraries/Connect/Interfaces/HTTPMetrics.swift
@@ -16,9 +16,9 @@ import Foundation
 
 /// Contains metrics collected during the span of an HTTP request.
 public struct HTTPMetrics: Sendable {
-    public let taskMetrics: URLSessionTaskMetrics
+    public let taskMetrics: URLSessionTaskMetrics?
 
-    public init(taskMetrics: URLSessionTaskMetrics) {
+    public init(taskMetrics: URLSessionTaskMetrics?) {
         self.taskMetrics = taskMetrics
     }
 }

--- a/Libraries/Connect/Interfaces/HTTPMetrics.swift
+++ b/Libraries/Connect/Interfaces/HTTPMetrics.swift
@@ -1,0 +1,24 @@
+// Copyright 2022-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Contains metrics from HTTP requests/streams.
+public struct HTTPMetrics: Sendable {
+    public let taskMetrics: URLSessionTaskMetrics
+
+    public init(taskMetrics: URLSessionTaskMetrics) {
+        self.taskMetrics = taskMetrics
+    }
+}

--- a/Libraries/Connect/Interfaces/HTTPMetrics.swift
+++ b/Libraries/Connect/Interfaces/HTTPMetrics.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-/// Contains metrics from HTTP requests/streams.
+/// Contains metrics collected during the span of an HTTP request.
 public struct HTTPMetrics: Sendable {
     public let taskMetrics: URLSessionTaskMetrics
 

--- a/Libraries/Connect/Interfaces/Interceptor.swift
+++ b/Libraries/Connect/Interfaces/Interceptor.swift
@@ -45,7 +45,7 @@ public struct UnaryFunction {
     public init(
         requestFunction: @escaping (HTTPRequest) -> HTTPRequest,
         responseFunction: @escaping (HTTPResponse) -> HTTPResponse,
-        responseMetricsFunction: @escaping (HTTPMetrics) -> HTTPMetrics
+        responseMetricsFunction: @escaping (HTTPMetrics) -> HTTPMetrics = { $0 }
     ) {
         self.requestFunction = requestFunction
         self.responseFunction = responseFunction

--- a/Libraries/Connect/Interfaces/Interceptor.swift
+++ b/Libraries/Connect/Interfaces/Interceptor.swift
@@ -40,13 +40,16 @@ public protocol Interceptor {
 public struct UnaryFunction {
     public let requestFunction: (HTTPRequest) -> HTTPRequest
     public let responseFunction: (HTTPResponse) -> HTTPResponse
+    public let responseMetricsFunction: (HTTPMetrics) -> HTTPMetrics
 
     public init(
         requestFunction: @escaping (HTTPRequest) -> HTTPRequest,
-        responseFunction: @escaping (HTTPResponse) -> HTTPResponse
+        responseFunction: @escaping (HTTPResponse) -> HTTPResponse,
+        responseMetricsFunction: @escaping (HTTPMetrics) -> HTTPMetrics
     ) {
         self.requestFunction = requestFunction
         self.responseFunction = responseFunction
+        self.responseMetricsFunction = responseMetricsFunction
     }
 }
 

--- a/Tests/ConnectLibraryTests/ConnectTests/InterceptorChainTests.swift
+++ b/Tests/ConnectLibraryTests/ConnectTests/InterceptorChainTests.swift
@@ -159,6 +159,9 @@ final class InterceptorChainTests: XCTestCase {
         ))
         XCTAssertEqual(interceptedResponse.headers["filter-chain"], ["filter-b", "filter-a"])
 
+        let interceptedMetrics = chain.responseMetricsFunction(HTTPMetrics(taskMetrics: nil))
+        XCTAssertEqual(interceptedMetrics.taskMetrics, nil)
+
         XCTAssertEqual(XCTWaiter().wait(for: [
             aRequestExpectation,
             bRequestExpectation,

--- a/Tests/ConnectLibraryTests/ConnectTests/InterceptorChainTests.swift
+++ b/Tests/ConnectLibraryTests/ConnectTests/InterceptorChainTests.swift
@@ -19,6 +19,7 @@ private struct MockUnaryInterceptor: Interceptor {
     let headerID: String
     let requestExpectation: XCTestExpectation
     let responseExpectation: XCTestExpectation
+    let responseMetricsExpectation: XCTestExpectation
 
     func unaryFunction() -> Connect.UnaryFunction {
         return UnaryFunction(
@@ -45,6 +46,10 @@ private struct MockUnaryInterceptor: Interceptor {
                     error: response.error,
                     tracingInfo: .init(httpStatus: 200)
                 )
+            },
+            responseMetricsFunction: { metrics in
+                self.responseMetricsExpectation.fulfill()
+                return metrics
             }
         )
     }
@@ -112,20 +117,24 @@ final class InterceptorChainTests: XCTestCase {
         let bRequestExpectation = self.expectation(description: "Filter B called with request")
         let aResponseExpectation = self.expectation(description: "Filter A called with response")
         let bResponseExpectation = self.expectation(description: "Filter B called with response")
+        let aMetricsExpectation = self.expectation(description: "Filter A called with metrics")
+        let bMetricsExpectation = self.expectation(description: "Filter B called with metrics")
         let chain = InterceptorChain(
             interceptors: [
                 { _ in
                     return MockUnaryInterceptor(
                         headerID: "filter-a",
                         requestExpectation: aRequestExpectation,
-                        responseExpectation: aResponseExpectation
+                        responseExpectation: aResponseExpectation,
+                        responseMetricsExpectation: aMetricsExpectation
                     )
                 },
                 { _ in
                     return MockUnaryInterceptor(
                         headerID: "filter-b",
                         requestExpectation: bRequestExpectation,
-                        responseExpectation: bResponseExpectation
+                        responseExpectation: bResponseExpectation,
+                        responseMetricsExpectation: bMetricsExpectation
                     )
                 },
             ],
@@ -155,6 +164,8 @@ final class InterceptorChainTests: XCTestCase {
             bRequestExpectation,
             bResponseExpectation,
             aResponseExpectation,
+            aMetricsExpectation,
+            bMetricsExpectation,
         ], timeout: 1.0, enforceOrder: true), .completed)
     }
 

--- a/Tests/ConnectLibraryTests/ConnectTests/InterceptorChainTests.swift
+++ b/Tests/ConnectLibraryTests/ConnectTests/InterceptorChainTests.swift
@@ -164,8 +164,8 @@ final class InterceptorChainTests: XCTestCase {
             bRequestExpectation,
             bResponseExpectation,
             aResponseExpectation,
-            aMetricsExpectation,
             bMetricsExpectation,
+            aMetricsExpectation,
         ], timeout: 1.0, enforceOrder: true), .completed)
     }
 

--- a/Tests/ConnectLibraryTests/ConnectTests/InterceptorChainTests.swift
+++ b/Tests/ConnectLibraryTests/ConnectTests/InterceptorChainTests.swift
@@ -160,7 +160,7 @@ final class InterceptorChainTests: XCTestCase {
         XCTAssertEqual(interceptedResponse.headers["filter-chain"], ["filter-b", "filter-a"])
 
         let interceptedMetrics = chain.responseMetricsFunction(HTTPMetrics(taskMetrics: nil))
-        XCTAssertEqual(interceptedMetrics.taskMetrics, nil)
+        XCTAssertNil(interceptedMetrics.taskMetrics)
 
         XCTAssertEqual(XCTWaiter().wait(for: [
             aRequestExpectation,

--- a/Tests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
+++ b/Tests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
@@ -18,7 +18,9 @@ import XCTest
 
 private struct NoopInterceptor: Interceptor {
     func unaryFunction() -> UnaryFunction {
-        return .init(requestFunction: { $0 }, responseFunction: { $0 })
+        return .init(
+            requestFunction: { $0 }, responseFunction: { $0 }, responseMetricsFunction: { $0 }
+        )
     }
 
     func streamFunction() -> StreamFunction {


### PR DESCRIPTION
Adds the ability for interceptors to receive metrics data via a new closure. This is helpful for tracing, i.e., when building an interceptor that:
- Creates a trace span when a request is sent, stores that span on itself, and optionally alters the request headers
- Closes the span when a response is received
- Adds additional information to the span when metrics are provided

Ideally, this information would be included in the response callback itself (i.e., within the `HTTPResponse`), but `URLSession` does not provide `URLSessionTaskMetrics` at the same time that it provides the response. Furthermore, metrics tend to arrive after the response completes, and blocking the response from being passed back to the caller while waiting for metrics does not make sense. Instead, a new callback is being added to unary interceptors.

Example:

```swift
private final class SampleInterceptor: Interceptor {
    func unaryFunction() -> Connect.UnaryFunction {
        return .init(
            requestFunction: { $0 },
            responseFunction: { $0 },
            responseMetricsFunction: { metrics in
                print("**Metrics: \(metrics)")
                return metrics
            }
        )
    }

    func streamFunction() -> Connect.StreamFunction {
        fatalError()
    }
}
```

Which prints something like this:

```
**Metrics: HTTPMetrics(taskMetrics: (Task Interval) <_NSConcreteDateInterval: 0x600003654e20> (Start Date) 2023-03-03 23:19:10 +0000 + (Duration) 0.326617 seconds = (End Date) 2023-03-03 23:19:10 +0000
(Redirect Count) 0
(Transaction Metrics) (Request) <NSMutableURLRequest: 0x6000034bb4c0> { URL: https://demo.connect.build/buf.connect.demo.eliza.v1.ElizaService/Say }
(Response) <NSHTTPURLResponse: 0x6000037a6a60> { URL: https://demo.connect.build/buf.connect.demo.eliza.v1.ElizaService/Say } { Status Code: 200, Headers {
    "Accept-Encoding" =     (
        gzip
    );
    "Alt-Svc" =     (
        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
    );
    "Content-Length" =     (
        55
    );
    "Content-Type" =     (
        "application/proto"
    );
    Date =     (
        "Fri, 03 Mar 2023 23:18:54 GMT"
    );
    Server =     (
        "Google Frontend"
    );
    Vary =     (
        Origin
    );
    Via =     (
        "1.1 google"
    );
    traceparent =     (
        "00-9241f673bcbbcd032a5916609af966dc-8c76b9eb554865b1-01"
    );
    "x-cloud-trace-context" =     (
        "9241f673bcbbcd032a5916609af966dc/10121481632961029553;o=1"
    );
} }
(Fetch Start) 2023-03-03 23:19:10 +0000
(Domain Lookup Start) (null)
(Domain Lookup End) (null)
(Connect Start) (null)
(Secure Connection Start) (null)
(Secure Connection End) (null)
(Connect End) (null)
(Request Start) 2023-03-03 23:19:10 +0000
(Request End) 2023-03-03 23:19:10 +0000
(Response Start) 2023-03-03 23:19:10 +0000
(Response End) 2023-03-03 23:19:10 +0000
(Protocol Name) (null)
(Proxy Connection) NO
(Reused Connection) NO
(Fetch Type) Local Cache
(Request Header Bytes) 0
(Request Body Transfer Bytes) 0
(Request Body Bytes) 0
(Response Header Bytes) 0
(Response Body Transfer Bytes) 0
(Response Body Bytes) 0
(Local Address) (null)
(Local Port) (null)
(Remote Address) (null)
(Remote Port) (null)
(TLS Protocol Version) 0x0000
(TLS Cipher Suite) 0x0000
(Cellular) NO
(Expensive) NO
(Constrained) NO
(Multipath) NO

(Request) <NSURLRequest: 0x6000034bb480> { URL: https://demo.connect.build/buf.connect.demo.eliza.v1.ElizaService/Say }
(Response) <NSHTTPURLResponse: 0x6000037afa60> { URL: https://demo.connect.build/buf.connect.demo.eliza.v1.ElizaService/Say } { Status Code: 200, Headers {
    "Accept-Encoding" =     (
        gzip
    );
    "Alt-Svc" =     (
        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
    );
    "Content-Length" =     (
        55
    );
    "Content-Type" =     (
        "application/proto"
    );
    Date =     (
        "Fri, 03 Mar 2023 23:19:10 GMT"
    );
    Server =     (
        "Google Frontend"
    );
    Vary =     (
        Origin
    );
    Via =     (
        "1.1 google"
    );
    traceparent =     (
        "00-ae364b402513689f7fec0ca19ec0e48c-58203dacb495c785-01"
    );
    "x-cloud-trace-context" =     (
        "ae364b402513689f7fec0ca19ec0e48c/6350143286565783429;o=1"
    );
} }
(Fetch Start) 2023-03-03 23:19:10 +0000
(Domain Lookup Start) 2023-03-03 23:19:10 +0000
(Domain Lookup End) 2023-03-03 23:19:10 +0000
(Connect Start) 2023-03-03 23:19:10 +0000
(Secure Connection Start) 2023-03-03 23:19:10 +0000
(Secure Connection End) 2023-03-03 23:19:10 +0000
(Connect End) 2023-03-03 23:19:10 +0000
(Request Start) 2023-03-03 23:19:10 +0000
(Request End) 2023-03-03 23:19:10 +0000
(Response Start) 2023-03-03 23:19:10 +0000
(Response End) 2023-03-03 23:19:10 +0000
(Protocol Name) h3
(Proxy Connection) NO
(Reused Connection) NO
(Fetch Type) Network Load
(Request Header Bytes) 170
(Request Body Transfer Bytes) 0
(Request Body Bytes) 6
(Response Header Bytes) 243
(Response Body Transfer Bytes) 57
(Response Body Bytes) 55
(Local Address) 192.168.13.223
(Local Port) 64004
(Remote Address) 35.227.208.237
(Remote Port) 443
(TLS Protocol Version) 0x0304
(TLS Cipher Suite) 0x1301
(Cellular) NO
(Expensive) NO
(Constrained) NO
(Multipath) NO

)
```