### PR TITLE
Update GitHub release job to run on new tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     tags:
       - "*"
   workflow_dispatch: {} # support manual runs
+permissions:
+  contents: write
 jobs:
   plugin-artifacts:
     runs-on: macos-12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,9 @@ jobs:
           mkdir -p ./.tmp/artifacts
           tar -zcvf ./.tmp/artifacts/protoc-gen-connect-swift.tar.gz ./.tmp/bin/protoc-gen-connect-swift
           tar -zcvf ./.tmp/artifacts/protoc-gen-connect-swift-mocks.tar.gz ./.tmp/bin/protoc-gen-connect-swift-mocks
-      - name: Release
+      - name: Publish release
         uses: softprops/action-gh-release@v1
         with:
+          generate_release_notes: true
           files: |
             ./.tmp/artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: write
 jobs:
-  plugin-artifacts:
+  release:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
@@ -25,5 +25,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
+          append_body: true
           files: |
             ./.tmp/artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,8 @@ name: release
 on:
   push:
     tags:
+      - "*"
   workflow_dispatch: {} # support manual runs
-permissions:
-  contents: read
 jobs:
   plugin-artifacts:
     runs-on: macos-12
@@ -17,16 +16,11 @@ jobs:
         run: make buildplugins
       - name: Zip artifacts
         run: |
-          cd ./.tmp/bin
-          tar -zcvf protoc-gen-connect-swift.tar.gz protoc-gen-connect-swift
-          tar -zcvf protoc-gen-connect-swift-mocks.tar.gz protoc-gen-connect-swift-mocks
-      - name: Upload protoc-gen-connect-swift artifact
-        uses: actions/upload-artifact@v3
+          mkdir -p ./.tmp/artifacts
+          tar -zcvf ./.tmp/artifacts/protoc-gen-connect-swift.tar.gz ./.tmp/bin/protoc-gen-connect-swift
+          tar -zcvf ./.tmp/artifacts/protoc-gen-connect-swift-mocks.tar.gz ./.tmp/bin/protoc-gen-connect-swift-mocks
+      - name: Release
+        uses: softprops/action-gh-release@v1
         with:
-          name: protoc-gen-connect-swift.tar.gz
-          path: ./.tmp/bin/protoc-gen-connect-swift.tar.gz
-      - name: Upload protoc-gen-connect-swift-mocks artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: protoc-gen-connect-swift-mocks.tar.gz
-          path: ./.tmp/bin/protoc-gen-connect-swift-mocks.tar.gz
+          files: |
+            ./.tmp/artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,14 @@ jobs:
         run: make buildplugins
       - name: Zip artifacts
         run: |
-          mkdir -p ./.tmp/artifacts
-          tar -zcvf ./.tmp/artifacts/protoc-gen-connect-swift.tar.gz ./.tmp/bin/protoc-gen-connect-swift
-          tar -zcvf ./.tmp/artifacts/protoc-gen-connect-swift-mocks.tar.gz ./.tmp/bin/protoc-gen-connect-swift-mocks
+          cd ./.tmp/bin
+          tar -zcvf ./protoc-gen-connect-swift.tar.gz ./protoc-gen-connect-swift
+          tar -zcvf ./protoc-gen-connect-swift-mocks.tar.gz ./protoc-gen-connect-swift-mocks
       - name: Publish release
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
           append_body: true
           files: |
-            ./.tmp/artifacts/*
+            ./.tmp/bin/protoc-gen-connect-swift.tar.gz
+            ./.tmp/bin/protoc-gen-connect-swift-mocks.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: release
 on:
-  release:
-    types: [published]
+  push:
+    tags:
   workflow_dispatch: {} # support manual runs
 permissions:
   contents: read


### PR DESCRIPTION
- Updates the release job to run whenever a new tag is created
- Publishes a release for the tag and adds/appends release notes
- Correctly uploads `.tar.gz` artifacts for both the `protoc-gen-connect-swift` and `protoc-gen-connect-swift-mocks` plugins to the release

This workflow is based on the [one used upstream in `buf`](https://github.com/bufbuild/buf/blob/bdbb114d40a48c8ad1ec83204aa1155845ddd745/.github/workflows/release.yaml#L149).

This produces something like the following release:

<img width="936" alt="Screenshot 2023-03-06 at 4 57 03 PM" src="https://user-images.githubusercontent.com/2643476/223292519-6a2fb39f-4a08-4fcc-b60f-f671e8c9bc35.png">

Resolves #101.