### PR TITLE
Update release job to generate `sha256.txt`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,17 @@ jobs:
       - name: Zip artifacts
         run: |
           cd ./.tmp/bin
-          tar -zcvf ./protoc-gen-connect-swift.tar.gz ./protoc-gen-connect-swift
-          tar -zcvf ./protoc-gen-connect-swift-mocks.tar.gz ./protoc-gen-connect-swift-mocks
+          mkdir ./artifacts
+          tar -zcvf ./artifacts/protoc-gen-connect-swift.tar.gz ./protoc-gen-connect-swift
+          tar -zcvf ./artifacts/protoc-gen-connect-swift-mocks.tar.gz ./protoc-gen-connect-swift-mocks
+          cd ./artifacts
+          for file in $(find . -maxdepth 1 -type f | sed 's/^\.\///' | sort | uniq); do
+            shasum -a 256 "${file}" >> sha256.txt
+          done
       - name: Publish release
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
           append_body: true
           files: |
-            ./.tmp/bin/protoc-gen-connect-swift.tar.gz
-            ./.tmp/bin/protoc-gen-connect-swift-mocks.tar.gz
+            ./.tmp/bin/artifacts/*


### PR DESCRIPTION
Example output of this file:

```
c789c3b8fa95eabe3772b34469a8582a0373f7cd33a42af865930587f5e9e14b  protoc-gen-connect-swift-mocks.tar.gz
ba72bb72ebdf151b8134b5fdf8e3b4c96f20d1e90a449d12f8209d6d4f274a5b  protoc-gen-connect-swift.tar.gz
```

This is similar to another [another buf release script](https://github.com/bufbuild/buf/blob/bdbb114d40a48c8ad1ec83204aa1155845ddd745/make/buf/scripts/release.bash#LL137-L140C21).