### PR TITLE
Allow building for tvOS

### DIFF
--- a/Connect-Swift-Mocks.podspec
+++ b/Connect-Swift-Mocks.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |spec|
 
   spec.ios.deployment_target = '14.0'
   spec.osx.deployment_target = '10.15'
+  spec.tvos.deployment_target = '13.0'
 
   spec.dependency 'Connect-Swift', "#{spec.version.to_s}"
   spec.dependency 'SwiftProtobuf', '~> 1.21.0'

--- a/Connect-Swift.podspec
+++ b/Connect-Swift.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |spec|
 
   spec.ios.deployment_target = '14.0'
   spec.osx.deployment_target = '10.15'
+  spec.tvos.deployment_target = '13.0'
 
   spec.dependency 'SwiftProtobuf', '~> 1.21.0'
 

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
     platforms: [
         .iOS(.v12),
         .macOS(.v10_15),
+        .tvOS(.v13),
     ],
     products: [
         .library(


### PR DESCRIPTION
There wasn't anything blocking tvOS, it just wasn't marked as being supported.

Resolves https://github.com/bufbuild/connect-swift/issues/117.