### PR TITLE
Update podspecs to match `Package.swift` targets

### DIFF
--- a/Connect-Swift-Mocks.podspec
+++ b/Connect-Swift-Mocks.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |spec|
   spec.author = 'Buf Technologies, Inc.'
   spec.source = { :git => 'https://github.com/bufbuild/connect-swift.git', :tag => spec.version }
 
-  spec.ios.deployment_target = '14.0'
+  spec.ios.deployment_target = '12.0'
   spec.osx.deployment_target = '10.15'
 
   spec.dependency 'Connect-Swift', "#{spec.version.to_s}"

--- a/Connect-Swift.podspec
+++ b/Connect-Swift.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |spec|
   spec.author = 'Buf Technologies, Inc.'
   spec.source = { :git => 'https://github.com/bufbuild/connect-swift.git', :tag => spec.version }
 
-  spec.ios.deployment_target = '14.0'
+  spec.ios.deployment_target = '12.0'
   spec.osx.deployment_target = '10.15'
 
   spec.dependency 'SwiftProtobuf', '~> 1.21.0'


### PR DESCRIPTION
`Package.swift` is marked to support iOS 12, and the podspecs should be as well.