### PR TITLE
Add @available annotations to ConnectMocks streams

### DIFF
--- a/Libraries/ConnectMocks/MockBidirectionalStream.swift
+++ b/Libraries/ConnectMocks/MockBidirectionalStream.swift
@@ -23,6 +23,7 @@ import SwiftProtobuf
 /// or by subclassing the type and overriding functions such as `send()`.
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)`.
+@available(iOS 13.0, *)
 open class MockBidirectionalStream<
     Input: SwiftProtobuf.Message,
     Output: SwiftProtobuf.Message

--- a/Libraries/ConnectMocks/MockClientOnlyStream.swift
+++ b/Libraries/ConnectMocks/MockClientOnlyStream.swift
@@ -22,6 +22,7 @@ import SwiftProtobuf
 /// or by subclassing the type and overriding functions such as `send()`.
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)`.
+@available(iOS 13.0, *)
 open class MockClientOnlyStream<
     Input: SwiftProtobuf.Message,
     Output: SwiftProtobuf.Message

--- a/Libraries/ConnectMocks/MockServerOnlyStream.swift
+++ b/Libraries/ConnectMocks/MockServerOnlyStream.swift
@@ -23,6 +23,7 @@ import SwiftProtobuf
 /// or by subclassing the type and overriding functions such as `send()`.
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)`.
+@available(iOS 13.0, *)
 open class MockServerOnlyStream<
     Input: SwiftProtobuf.Message,
     Output: SwiftProtobuf.Message


### PR DESCRIPTION
This fixes a compilation error that prevented me from using ConnectMocks in my app. The app targets iOS 15, but ConnectMocks didn't compile because it targets iOS 12, and the `@Published` property wrapper that some of its classes use is only available in iOS 13 and higher.

This PR adds `@available(iOS 13.0, *)` to fix the problem.