### PR TITLE
Add `available(iOS 13)` to remaining ConnectMocks classes

### DIFF
--- a/Libraries/ConnectMocks/MockBidirectionalStream.swift
+++ b/Libraries/ConnectMocks/MockBidirectionalStream.swift
@@ -23,6 +23,7 @@ import SwiftProtobuf
 /// or by subclassing the type and overriding functions such as `send()`.
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)`.
+@available(iOS 13.0, *)
 open class MockBidirectionalStream<
     Input: SwiftProtobuf.Message,
     Output: SwiftProtobuf.Message

--- a/Libraries/ConnectMocks/MockClientOnlyStream.swift
+++ b/Libraries/ConnectMocks/MockClientOnlyStream.swift
@@ -22,6 +22,7 @@ import SwiftProtobuf
 /// or by subclassing the type and overriding functions such as `send()`.
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)`.
+@available(iOS 13.0, *)
 open class MockClientOnlyStream<
     Input: SwiftProtobuf.Message,
     Output: SwiftProtobuf.Message

--- a/Libraries/ConnectMocks/MockServerOnlyStream.swift
+++ b/Libraries/ConnectMocks/MockServerOnlyStream.swift
@@ -23,6 +23,7 @@ import SwiftProtobuf
 /// or by subclassing the type and overriding functions such as `send()`.
 ///
 /// To return data over the stream, outputs can be specified using `init(outputs: ...)`.
+@available(iOS 13.0, *)
 open class MockServerOnlyStream<
     Input: SwiftProtobuf.Message,
     Output: SwiftProtobuf.Message


### PR DESCRIPTION
<img width="410" alt="Screenshot 2023-06-01 at 9 40 57 AM" src="https://github.com/bufbuild/connect-swift/assets/6375297/2c075ba9-da6f-4972-a4eb-0689344317b7">

This adds `@available(iOS 13.0, *)` tags to the rest of the classes in ConnectMocks that don't have it. Currently generating mocks on iOS results in a broken build.