### PR TITLE
Resolve Xcode 14.3 test warning

### DIFF
--- a/Tests/ConnectLibraryTests/ConnectTests/ConnectErrorTests.swift
+++ b/Tests/ConnectLibraryTests/ConnectTests/ConnectErrorTests.swift
@@ -93,7 +93,7 @@ final class ConnectErrorTests: XCTestCase {
                     "type": type(of: detail).protoMessageName,
                     "value": try detail.serializedData().base64EncodedString(),
                     "debug": ["retryDelay": "30s"],
-                ]
+                ] as [String: Any]
             },
         ]
         return try JSONSerialization.data(withJSONObject: dictionary)


### PR DESCRIPTION
Resolves the following warning when building with Xcode 14.3:

```
connect-swift/Tests/ConnectLibraryTests/ConnectTests/ConnectErrorTests.swift:92:17: warning: heterogeneous collection literal could only be inferred to '[String : Any]'; add explicit type annotation if this is intentional
        [
        ^
```