### PR TITLE
Fix new Swift 6 warning

### DIFF
--- a/Libraries/Connect/Implementation/ProtocolClient.swift
+++ b/Libraries/Connect/Implementation/ProtocolClient.swift
@@ -306,9 +306,7 @@ extension ProtocolClient: ProtocolClientInterface {
 }
 
 private extension StreamResult<Data> {
-    func toTypedResult<Output: SwiftProtobuf.Message>(using codec: Codec)
-        throws -> StreamResult<Output>
-    {
+    func toTypedResult<M: SwiftProtobuf.Message>(using codec: Codec) throws -> StreamResult<M> {
         switch self {
         case .complete(let code, let error, let trailers):
             return .complete(code: code, error: error, trailers: trailers)


### PR DESCRIPTION
Fixes this warning:

> Generic parameter 'Output' shadows generic parameter from outer scope with the same name; this is an error in Swift 6
