### PR TITLE
Replace buf and connect with connectrpc.com

### DIFF
--- a/Examples/ElizaCocoaPodsApp/README.md
+++ b/Examples/ElizaCocoaPodsApp/README.md
@@ -2,13 +2,13 @@
 
 This example app imports the `Connect` library using CocoaPods,
 and provides an interface for
-[chatting with Eliza](https://connect.build/demo).
+[chatting with Eliza](https://connectrpc.com/demo).
 
 The app has support for chatting using a variety of protocols supported by
 the Connect library:
 
-- [Connect](https://connect.build) + unary
-- [Connect](https://connect.build) + streaming
+- [Connect](https://connectrpc.com) + unary
+- [Connect](https://connectrpc.com) + streaming
 - [gRPC-Web](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md) + unary
 - [gRPC-Web](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md) + streaming
 

--- a/Examples/ElizaSharedSources/AppSources/MenuView.swift
+++ b/Examples/ElizaSharedSources/AppSources/MenuView.swift
@@ -41,7 +41,7 @@ struct MenuView: View {
     private func createClient(withProtocol networkProtocol: NetworkProtocol)
         -> Buf_Connect_Demo_Eliza_V1_ElizaServiceClient
     {
-        let host = "https://demo.connect.build"
+        let host = "https://demo.connectrpc.com"
         #if COCOAPODS
         let protocolClient = ProtocolClient(
             httpClient: URLSessionHTTPClient(),

--- a/Examples/ElizaSwiftPackageApp/README.md
+++ b/Examples/ElizaSwiftPackageApp/README.md
@@ -2,13 +2,13 @@
 
 This example app imports the `Connect` library using Swift Package Manager,
 and provides an interface for
-[chatting with Eliza](https://buf.build/bufbuild/eliza).
+[chatting with Eliza](https://connectrpc.com/bufbuild/eliza).
 
 The app has support for chatting using a variety of protocols supported by
 the Connect library:
 
-- [Connect](https://connect.build) + unary
-- [Connect](https://connect.build) + streaming
+- [Connect](https://connectrpc.com) + unary
+- [Connect](https://connectrpc.com) + streaming
 - [gRPC](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) + unary (using `ConnectGRPC` + `SwiftNIO`)
 - [gRPC](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) + streaming (using `ConnectGRPC` + `SwiftNIO`)
 - [gRPC-Web](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md) + unary

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -8,4 +8,4 @@ each supported protocol using either unary or streaming APIs:
   **Swift Package Manager**.
 - [`ElizaCocoaPodsApp`](./ElizaCocoaPodsApp): Uses **CocoaPods**.
 
-[eliza-demo]: https://connect.build/demo
+[eliza-demo]: https://connectrpc.com/demo

--- a/Libraries/Connect/Implementation/Codecs/Envelope.swift
+++ b/Libraries/Connect/Implementation/Codecs/Envelope.swift
@@ -29,7 +29,7 @@ public enum Envelope {
     /// Computes the length of the message contained by a packed chunk of data.
     /// A packed chunk in this context refers to prefixed message data.
     ///
-    /// Compliant with Connect streams: https://connect.build/docs/protocol/#streaming-request
+    /// Compliant with Connect streams: https://connectrpc.com/docs/protocol/#streaming-request
     /// And gRPC: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses
     ///
     /// - parameter data: The packed data from which to determine the enveloped message's size.
@@ -52,7 +52,7 @@ public enum Envelope {
     /// Packs a message into an "envelope", adding required header bytes and optionally
     /// applying compression.
     ///
-    /// Compliant with Connect streams: https://connect.build/docs/protocol/#streaming-request
+    /// Compliant with Connect streams: https://connectrpc.com/docs/protocol/#streaming-request
     /// And gRPC: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
     ///
     /// - parameter source: The input message data.
@@ -83,7 +83,7 @@ public enum Envelope {
     ///
     /// **Expects a fully framed envelope, not a partial message.**
     ///
-    /// Compliant with Connect streams: https://connect.build/docs/protocol/#streaming-response
+    /// Compliant with Connect streams: https://connectrpc.com/docs/protocol/#streaming-response
     /// And gRPC: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses
     ///
     /// - parameter source: The full envelope's data (header bytes + message bytes).

--- a/Libraries/Connect/Implementation/Interceptors/ConnectInterceptor.swift
+++ b/Libraries/Connect/Implementation/Interceptors/ConnectInterceptor.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// Implementation of the Connect protocol as an interceptor.
-/// https://connect.build/docs/protocol
+/// https://connectrpc.com/docs/protocol
 struct ConnectInterceptor {
     private let config: ProtocolClientConfig
 
@@ -138,7 +138,7 @@ extension ConnectInterceptor: Interceptor {
                         let isEndStream = 0b00000010 & headerByte != 0
                         if isEndStream {
                             // Expect a valid Connect end stream response, which can simply be {}.
-                            // https://connect.build/docs/protocol#error-end-stream
+                            // https://connectrpc.com/docs/protocol#error-end-stream
                             let response = try JSONDecoder().decode(
                                 ConnectEndStreamResponse.self, from: message
                             )

--- a/Libraries/Connect/Implementation/ProtocolClientConfig.swift
+++ b/Libraries/Connect/Implementation/ProtocolClientConfig.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// Configuration used to set up `ProtocolClientInterface` implementations.
 public struct ProtocolClientConfig {
-    /// Target host (e.g., `https://buf.build`).
+    /// Target host (e.g., `https://connectrpc.com`).
     public let host: String
     /// Protocol to use for requests and streams.
     public let networkProtocol: NetworkProtocol

--- a/Libraries/Connect/Interfaces/Code.swift
+++ b/Libraries/Connect/Interfaces/Code.swift
@@ -73,7 +73,7 @@ public enum Code: Int, CaseIterable, Equatable, Sendable {
     }
 
     public static func fromHTTPStatus(_ status: Int) -> Self {
-        // https://connect.build/docs/protocol#http-to-error-code
+        // https://connectrpc.com/docs/protocol#http-to-error-code
         switch status {
         case 200:
             return .ok

--- a/Libraries/Connect/Interfaces/ConnectEndStreamResponse.swift
+++ b/Libraries/Connect/Interfaces/ConnectEndStreamResponse.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// Structure modeling the final JSON message that is returned by Connect streams:
-/// https://connect.build/docs/protocol#error-end-stream
+/// https://connectrpc.com/docs/protocol#error-end-stream
 struct ConnectEndStreamResponse: Sendable {
     /// Connect error that was returned with the response.
     let error: ConnectError?

--- a/Libraries/Connect/Interfaces/HTTPResponse.swift
+++ b/Libraries/Connect/Interfaces/HTTPResponse.swift
@@ -17,7 +17,7 @@ import Foundation
 /// Unary HTTP response received from the server.
 public struct HTTPResponse: Sendable {
     /// The status code of the response.
-    /// See https://connect.build/docs/protocol/#error-codes for more info.
+    /// See https://connectrpc.com/docs/protocol/#error-codes for more info.
     public let code: Code
     /// Response headers specified by the server.
     public let headers: Headers

--- a/Libraries/Connect/Interfaces/NetworkProtocol.swift
+++ b/Libraries/Connect/Interfaces/NetworkProtocol.swift
@@ -15,7 +15,7 @@
 /// Protocols that are supported by the library.
 public enum NetworkProtocol {
     /// The Connect protocol:
-    /// https://connect.build/docs/protocol
+    /// https://connectrpc.com/docs/protocol
     case connect
     /// The gRPC-Web protocol:
     /// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md

--- a/Libraries/Connect/README.md
+++ b/Libraries/Connect/README.md
@@ -4,4 +4,4 @@ This module contains support for the Connect and gRPC-Web protocols.
 For gRPC support, you must also include the `ConnectNIO` module.
 
 For additional details and tutorials, see the
-[Connect-Swift documentation](https://connect.build/docs/swift/getting-started/).
+[Connect-Swift documentation](https://connectrpc.com/docs/swift/getting-started/).

--- a/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
+++ b/Libraries/ConnectNIO/Public/NIOHTTPClient.swift
@@ -47,11 +47,11 @@ open class NIOHTTPClient: Connect.HTTPClientInterface {
 
     /// Designated initializer for the client.
     ///
-    /// - parameter host: Target host (e.g., `https://buf.build`).
+    /// - parameter host: Target host (e.g., `https://connectrpc.com`).
     /// - parameter port: Port to use for the connection. A default is provided based on whether a
     ///                   secure connection is being established to the host via HTTPS. If this
     ///                   parameter is omitted and the `host` parameter includes a port
-    ///                   (e.g., `https://buf.build:8080`), the host's port will be used.
+    ///                   (e.g., `https://connectrpc.com:8080`), the host's port will be used.
     /// - parameter timeout: Optional timeout after which to terminate requests/streams if no
     ///                      activity has occurred in the request or response path.
     public init(host: String, port: Int? = nil, timeout: TimeInterval? = nil) {

--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ Offered under the [Apache 2 license](./LICENSE).
 
 [blog]: https://buf.build/blog/announcing-connect-swift
 [buf-studio]: https://buf.build/studio
-[connect-crosstest]: https://github.com/bufbuild/connect-crosstest
-[connect-go]: https://github.com/bufbuild/connect-go
-[connect-kotlin]: https://github.com/bufbuild/connect-kotlin
+[connect-crosstest]: https://github.com/connectrpc/connect-crosstest
+[connect-go]: https://github.com/connectrpc/connect-go
+[connect-kotlin]: https://github.com/connectrpc/connect-kotlin
 [connect-protocol]: https://connectrpc.com/docs/protocol
 [connect-web]: https://www.npmjs.com/package/@bufbuild/connect-web
 [error-handling]: https://connectrpc.com/docs/swift/errors

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ a working SwiftUI chat app that uses Connect-Swift!
 Comprehensive documentation for everything, including
 [interceptors][interceptors], [mocking/testing][testing],
 [streaming][streaming], and [error handling][error-handling]
-is available on the [connect.build website][getting-started].
+is available on the [connectrpc.com website][getting-started].
 
 ## Example Apps
 
@@ -174,15 +174,15 @@ Offered under the [Apache 2 license](./LICENSE).
 [connect-crosstest]: https://github.com/bufbuild/connect-crosstest
 [connect-go]: https://github.com/bufbuild/connect-go
 [connect-kotlin]: https://github.com/bufbuild/connect-kotlin
-[connect-protocol]: https://connect.build/docs/protocol
+[connect-protocol]: https://connectrpc.com/docs/protocol
 [connect-web]: https://www.npmjs.com/package/@bufbuild/connect-web
-[error-handling]: https://connect.build/docs/swift/errors
-[getting-started]: https://connect.build/docs/swift/getting-started
+[error-handling]: https://connectrpc.com/docs/swift/errors
+[getting-started]: https://connectrpc.com/docs/swift/getting-started
 [grpc-protocol]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
 [grpc-web-protocol]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md
-[interceptors]: https://connect.build/docs/swift/interceptors
+[interceptors]: https://connectrpc.com/docs/swift/interceptors
 [protobuf]: https://developers.google.com/protocol-buffers
 [slack]: https://buf.build/links/slack
-[streaming]: https://connect.build/docs/swift/using-clients#using-generated-clients
-[swift-pm-integration]: https://connect.build/docs/swift/getting-started#add-the-connect-swift-package
-[testing]: https://connect.build/docs/swift/testing
+[streaming]: https://connectrpc.com/docs/swift/using-clients#using-generated-clients
+[swift-pm-integration]: https://connectrpc.com/docs/swift/getting-started#add-the-connect-swift-package
+[testing]: https://connectrpc.com/docs/swift/testing

--- a/Tests/ConnectLibraryTests/ConnectTests/ConnectErrorTests.swift
+++ b/Tests/ConnectLibraryTests/ConnectTests/ConnectErrorTests.swift
@@ -84,7 +84,7 @@ final class ConnectErrorTests: XCTestCase {
     // MARK: - Private
 
     private func errorData(expectedDetails: [SwiftProtobuf.Message]) throws -> Data {
-        // Example error from https://connect.build/docs/protocol/#error-end-stream
+        // Example error from https://connectrpc.com/docs/protocol/#error-end-stream
         let dictionary: [String: Any] = [
             "code": "unavailable",
             "message": "overloaded: back off and retry",

--- a/Tests/ConnectLibraryTests/ConnectTests/InterceptorChainTests.swift
+++ b/Tests/ConnectLibraryTests/ConnectTests/InterceptorChainTests.swift
@@ -112,7 +112,7 @@ private struct MockStreamInterceptor: Interceptor {
 }
 
 final class InterceptorChainTests: XCTestCase {
-    private let config = ProtocolClientConfig(host: "https://buf.build")
+    private let config = ProtocolClientConfig(host: "https://connectrpc.com")
 
     func testUnary() throws {
         let aRequestExpectation = self.expectation(description: "Filter A called with request")
@@ -144,7 +144,7 @@ final class InterceptorChainTests: XCTestCase {
         ).unaryFunction()
 
         let interceptedRequest = chain.requestFunction(HTTPRequest(
-            url: try XCTUnwrap(URL(string: "https://buf.build/mock")),
+            url: try XCTUnwrap(URL(string: "https://connectrpc.com/mock")),
             contentType: "application/json",
             headers: Headers(),
             message: nil,
@@ -214,7 +214,7 @@ final class InterceptorChainTests: XCTestCase {
         ).streamFunction()
 
         let interceptedRequest = chain.requestFunction(HTTPRequest(
-            url: try XCTUnwrap(URL(string: "https://buf.build/mock")),
+            url: try XCTUnwrap(URL(string: "https://connectrpc.com/mock")),
             contentType: "application/json",
             headers: Headers(),
             message: nil,

--- a/Tests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
+++ b/Tests/ConnectLibraryTests/ConnectTests/ProtocolClientConfigTests.swift
@@ -36,7 +36,7 @@ private struct NoopInterceptor: Interceptor {
 
 final class ProtocolClientConfigTests: XCTestCase {
     func testDefaultResponseCompressionPoolIncludesGzip() {
-        let config = ProtocolClientConfig(host: "https://buf.build")
+        let config = ProtocolClientConfig(host: "https://connectrpc.com")
         XCTAssertTrue(config.responseCompressionPools[0] is GzipCompressionPool)
         XCTAssertEqual(config.acceptCompressionPoolNames(), ["gzip"])
     }
@@ -59,7 +59,7 @@ final class ProtocolClientConfigTests: XCTestCase {
 
     func testAddsConnectInterceptorLastWhenUsingConnectProtocol() {
         let config = ProtocolClientConfig(
-            host: "https://buf.build",
+            host: "https://connectrpc.com",
             networkProtocol: .connect,
             interceptors: [NoopInterceptor.init]
         )
@@ -69,7 +69,7 @@ final class ProtocolClientConfigTests: XCTestCase {
 
     func testAddsGRPCWebInterceptorLastWhenUsingGRPCWebProtocol() {
         let config = ProtocolClientConfig(
-            host: "https://buf.build",
+            host: "https://connectrpc.com",
             networkProtocol: .grpcWeb,
             interceptors: [NoopInterceptor.init]
         )


### PR DESCRIPTION
Searched for `connect.build` and `buf.build` to replace appropriate usages to `connectrpc.com`