### PR TITLE
Update SwiftProtobuf to 1.23.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -154,6 +154,7 @@ To update dependencies such as `SwiftProtobuf` in this repository:
    [`Connect-Swift-Mocks.podspec`](../Connect-Swift-Mocks.podspec) files.
 4. Open the [Swift package example app](../Examples/ElizaSwiftPackageApp) to ensure its `Package.resolved` file gets updated.
 5. Run `pod update` in the [CocoaPods example app's directory](../Examples/ElizaCocoaPodsApp).
+6. Update remote plugin entries (such as `buf.build/apple/swift`) in all `buf.gen.yaml` files to be in sync with their respective runtime libraries.
 
 ## Releasing
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -155,6 +155,7 @@ To update dependencies such as `SwiftProtobuf` in this repository:
 4. Open the [Swift package example app](../Examples/ElizaSwiftPackageApp) to ensure its `Package.resolved` file gets updated.
 5. Run `pod update` in the [CocoaPods example app's directory](../Examples/ElizaCocoaPodsApp).
 6. Update remote plugin entries (such as `buf.build/apple/swift`) in all `buf.gen.yaml` files to be in sync with their respective runtime libraries.
+7. Run `make generate` to apply any generated diffs from the newly updated plugins.
 
 ## Releasing
 

--- a/Connect-Swift-Mocks.podspec
+++ b/Connect-Swift-Mocks.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.tvos.deployment_target = '13.0'
 
   spec.dependency 'Connect-Swift', "#{spec.version.to_s}"
-  spec.dependency 'SwiftProtobuf', '~> 1.22.0'
+  spec.dependency 'SwiftProtobuf', '~> 1.23.0'
 
   spec.source_files = 'Libraries/ConnectMocks/**/*.swift'
 

--- a/Connect-Swift.podspec
+++ b/Connect-Swift.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |spec|
   spec.osx.deployment_target = '10.15'
   spec.tvos.deployment_target = '13.0'
 
-  spec.dependency 'SwiftProtobuf', '~> 1.22.0'
+  spec.dependency 'SwiftProtobuf', '~> 1.23.0'
 
   spec.source_files = 'Libraries/Connect/**/*.swift'
 

--- a/Examples/ElizaCocoaPodsApp/Podfile.lock
+++ b/Examples/ElizaCocoaPodsApp/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Connect-Swift (0.6.0):
-    - SwiftProtobuf (~> 1.22.0)
-  - SwiftProtobuf (1.22.0)
+    - SwiftProtobuf (~> 1.23.0)
+  - SwiftProtobuf (1.23.0)
 
 DEPENDENCIES:
   - Connect-Swift (from `../..`)
@@ -15,8 +15,8 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  Connect-Swift: ba76bc64b2153cacce4f7985a21d4d81473dac90
-  SwiftProtobuf: 40bd808372cb8706108f22d28f8ab4a6b9bc6989
+  Connect-Swift: ca072ef1a95341460bcc08074fc5d46ecc055fb9
+  SwiftProtobuf: b70d65f419fbfe61a2d58003456ca5da58e337d6
 
 PODFILE CHECKSUM: b598f373a6ab5add976b09c2ac79029bf2200d48
 

--- a/Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/ElizaSwiftPackageApp/ElizaSwiftPackageApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "f25867a208f459d3c5a06935dceb9083b11cd539",
-        "version" : "1.22.0"
+        "revision" : "cf62cdaea48b77f1a631e5cb3aeda6047c2cba1d",
+        "version" : "1.23.0"
       }
     }
   ],

--- a/Examples/buf.gen.yaml
+++ b/Examples/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift
+  - plugin: buf.build/apple/swift:v1.23.0
     opt: Visibility=Internal
     out: ./ElizaSharedSources/GeneratedSources
   - name: connect-swift

--- a/Libraries/Connect/buf.gen.yaml
+++ b/Libraries/Connect/buf.gen.yaml
@@ -1,5 +1,5 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift
+  - plugin: buf.build/apple/swift:v1.23.0
     opt: Visibility=Internal
     out: ./Implementation/Generated

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "f25867a208f459d3c5a06935dceb9083b11cd539",
-        "version" : "1.22.0"
+        "revision" : "cf62cdaea48b77f1a631e5cb3aeda6047c2cba1d",
+        "version" : "1.23.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -60,7 +60,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-protobuf.git",
-            from: "1.22.0"
+            from: "1.23.0"
         ),
     ],
     targets: [

--- a/Tests/ConnectLibraryTests/Generated/grpc/testing/messages.pb.swift
+++ b/Tests/ConnectLibraryTests/Generated/grpc/testing/messages.pb.swift
@@ -70,7 +70,7 @@ enum Grpc_Testing_PayloadType: SwiftProtobuf.Enum {
 
 extension Grpc_Testing_PayloadType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static var allCases: [Grpc_Testing_PayloadType] = [
+  static let allCases: [Grpc_Testing_PayloadType] = [
     .compressable,
   ]
 }
@@ -124,7 +124,7 @@ enum Grpc_Testing_GrpclbRouteType: SwiftProtobuf.Enum {
 
 extension Grpc_Testing_GrpclbRouteType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static var allCases: [Grpc_Testing_GrpclbRouteType] = [
+  static let allCases: [Grpc_Testing_GrpclbRouteType] = [
     .unknown,
     .fallback,
     .backend,
@@ -654,7 +654,7 @@ struct Grpc_Testing_ClientConfigureRequest {
 
 extension Grpc_Testing_ClientConfigureRequest.RpcType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static var allCases: [Grpc_Testing_ClientConfigureRequest.RpcType] = [
+  static let allCases: [Grpc_Testing_ClientConfigureRequest.RpcType] = [
     .emptyCall,
     .unaryCall,
   ]

--- a/Tests/ConnectLibraryTests/Generated/server/v1/server.pb.swift
+++ b/Tests/ConnectLibraryTests/Generated/server/v1/server.pb.swift
@@ -69,7 +69,7 @@ enum Server_V1_Protocol: SwiftProtobuf.Enum {
 
 extension Server_V1_Protocol: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static var allCases: [Server_V1_Protocol] = [
+  static let allCases: [Server_V1_Protocol] = [
     .unspecified,
     .grpc,
     .grpcWeb,

--- a/Tests/ConnectLibraryTests/buf.gen.yaml
+++ b/Tests/ConnectLibraryTests/buf.gen.yaml
@@ -1,6 +1,6 @@
 version: v1
 plugins:
-  - plugin: buf.build/apple/swift
+  - plugin: buf.build/apple/swift:v1.23.0
     opt: Visibility=Internal
     out: ./Generated
   - name: connect-swift


### PR DESCRIPTION
This also pins the SwiftProtobuf plugins in `buf.gen.yaml` files so that they don't change from under CI when a new update is released upstream.