### PR TITLE
Add leading slash to generated RPC paths

### DIFF
--- a/Examples/ElizaSharedSources/GeneratedSources/eliza.connect.swift
+++ b/Examples/ElizaSharedSources/GeneratedSources/eliza.connect.swift
@@ -41,16 +41,16 @@ internal final class Connectrpc_Eliza_V1_ElizaServiceClient: Connectrpc_Eliza_V1
 
     @available(iOS 13, *)
     internal func `say`(request: Connectrpc_Eliza_V1_SayRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Connectrpc_Eliza_V1_SayResponse> {
-        return await self.client.unary(path: "connectrpc.eliza.v1.ElizaService/Say", request: request, headers: headers)
+        return await self.client.unary(path: "/connectrpc.eliza.v1.ElizaService/Say", request: request, headers: headers)
     }
 
     @available(iOS 13, *)
     internal func `converse`(headers: Connect.Headers = [:]) -> any Connect.BidirectionalAsyncStreamInterface<Connectrpc_Eliza_V1_ConverseRequest, Connectrpc_Eliza_V1_ConverseResponse> {
-        return self.client.bidirectionalStream(path: "connectrpc.eliza.v1.ElizaService/Converse", headers: headers)
+        return self.client.bidirectionalStream(path: "/connectrpc.eliza.v1.ElizaService/Converse", headers: headers)
     }
 
     @available(iOS 13, *)
     internal func `introduce`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Connectrpc_Eliza_V1_IntroduceRequest, Connectrpc_Eliza_V1_IntroduceResponse> {
-        return self.client.serverOnlyStream(path: "connectrpc.eliza.v1.ElizaService/Introduce", headers: headers)
+        return self.client.serverOnlyStream(path: "/connectrpc.eliza.v1.ElizaService/Introduce", headers: headers)
     }
 }

--- a/Plugins/ConnectPluginUtilities/MethodDescriptor+Extensions.swift
+++ b/Plugins/ConnectPluginUtilities/MethodDescriptor+Extensions.swift
@@ -16,7 +16,7 @@ import SwiftProtobufPluginLibrary
 
 extension MethodDescriptor {
     public var methodPath: String {
-        return "\(self.service.servicePath)/\(self.name)"
+        return "/\(self.service.servicePath)/\(self.name)"
     }
 
     public func name(using options: GeneratorOptions) -> String {

--- a/Tests/ConnectLibraryTests/Generated/grpc/testing/test.connect.swift
+++ b/Tests/ConnectLibraryTests/Generated/grpc/testing/test.connect.swift
@@ -126,106 +126,106 @@ internal final class Grpc_Testing_TestServiceClient: Grpc_Testing_TestServiceCli
 
     @discardableResult
     internal func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "grpc.testing.TestService/EmptyCall", request: request, headers: headers, completion: completion)
+        return self.client.unary(path: "/grpc.testing.TestService/EmptyCall", request: request, headers: headers, completion: completion)
     }
 
     @available(iOS 13, *)
     internal func `emptyCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
-        return await self.client.unary(path: "grpc.testing.TestService/EmptyCall", request: request, headers: headers)
+        return await self.client.unary(path: "/grpc.testing.TestService/EmptyCall", request: request, headers: headers)
     }
 
     @discardableResult
     internal func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "grpc.testing.TestService/UnaryCall", request: request, headers: headers, completion: completion)
+        return self.client.unary(path: "/grpc.testing.TestService/UnaryCall", request: request, headers: headers, completion: completion)
     }
 
     @available(iOS 13, *)
     internal func `unaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
-        return await self.client.unary(path: "grpc.testing.TestService/UnaryCall", request: request, headers: headers)
+        return await self.client.unary(path: "/grpc.testing.TestService/UnaryCall", request: request, headers: headers)
     }
 
     @discardableResult
     internal func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "grpc.testing.TestService/FailUnaryCall", request: request, headers: headers, completion: completion)
+        return self.client.unary(path: "/grpc.testing.TestService/FailUnaryCall", request: request, headers: headers, completion: completion)
     }
 
     @available(iOS 13, *)
     internal func `failUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
-        return await self.client.unary(path: "grpc.testing.TestService/FailUnaryCall", request: request, headers: headers)
+        return await self.client.unary(path: "/grpc.testing.TestService/FailUnaryCall", request: request, headers: headers)
     }
 
     @discardableResult
     internal func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_SimpleResponse>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "grpc.testing.TestService/CacheableUnaryCall", request: request, headers: headers, completion: completion)
+        return self.client.unary(path: "/grpc.testing.TestService/CacheableUnaryCall", request: request, headers: headers, completion: completion)
     }
 
     @available(iOS 13, *)
     internal func `cacheableUnaryCall`(request: Grpc_Testing_SimpleRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_SimpleResponse> {
-        return await self.client.unary(path: "grpc.testing.TestService/CacheableUnaryCall", request: request, headers: headers)
+        return await self.client.unary(path: "/grpc.testing.TestService/CacheableUnaryCall", request: request, headers: headers)
     }
 
     internal func `streamingOutputCall`(headers: Connect.Headers = [:], onResult: @escaping (Connect.StreamResult<Grpc_Testing_StreamingOutputCallResponse>) -> Void) -> any Connect.ServerOnlyStreamInterface<Grpc_Testing_StreamingOutputCallRequest> {
-        return self.client.serverOnlyStream(path: "grpc.testing.TestService/StreamingOutputCall", headers: headers, onResult: onResult)
+        return self.client.serverOnlyStream(path: "/grpc.testing.TestService/StreamingOutputCall", headers: headers, onResult: onResult)
     }
 
     @available(iOS 13, *)
     internal func `streamingOutputCall`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
-        return self.client.serverOnlyStream(path: "grpc.testing.TestService/StreamingOutputCall", headers: headers)
+        return self.client.serverOnlyStream(path: "/grpc.testing.TestService/StreamingOutputCall", headers: headers)
     }
 
     internal func `failStreamingOutputCall`(headers: Connect.Headers = [:], onResult: @escaping (Connect.StreamResult<Grpc_Testing_StreamingOutputCallResponse>) -> Void) -> any Connect.ServerOnlyStreamInterface<Grpc_Testing_StreamingOutputCallRequest> {
-        return self.client.serverOnlyStream(path: "grpc.testing.TestService/FailStreamingOutputCall", headers: headers, onResult: onResult)
+        return self.client.serverOnlyStream(path: "/grpc.testing.TestService/FailStreamingOutputCall", headers: headers, onResult: onResult)
     }
 
     @available(iOS 13, *)
     internal func `failStreamingOutputCall`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
-        return self.client.serverOnlyStream(path: "grpc.testing.TestService/FailStreamingOutputCall", headers: headers)
+        return self.client.serverOnlyStream(path: "/grpc.testing.TestService/FailStreamingOutputCall", headers: headers)
     }
 
     internal func `streamingInputCall`(headers: Connect.Headers = [:], onResult: @escaping (Connect.StreamResult<Grpc_Testing_StreamingInputCallResponse>) -> Void) -> any Connect.ClientOnlyStreamInterface<Grpc_Testing_StreamingInputCallRequest> {
-        return self.client.clientOnlyStream(path: "grpc.testing.TestService/StreamingInputCall", headers: headers, onResult: onResult)
+        return self.client.clientOnlyStream(path: "/grpc.testing.TestService/StreamingInputCall", headers: headers, onResult: onResult)
     }
 
     @available(iOS 13, *)
     internal func `streamingInputCall`(headers: Connect.Headers = [:]) -> any Connect.ClientOnlyAsyncStreamInterface<Grpc_Testing_StreamingInputCallRequest, Grpc_Testing_StreamingInputCallResponse> {
-        return self.client.clientOnlyStream(path: "grpc.testing.TestService/StreamingInputCall", headers: headers)
+        return self.client.clientOnlyStream(path: "/grpc.testing.TestService/StreamingInputCall", headers: headers)
     }
 
     internal func `fullDuplexCall`(headers: Connect.Headers = [:], onResult: @escaping (Connect.StreamResult<Grpc_Testing_StreamingOutputCallResponse>) -> Void) -> any Connect.BidirectionalStreamInterface<Grpc_Testing_StreamingOutputCallRequest> {
-        return self.client.bidirectionalStream(path: "grpc.testing.TestService/FullDuplexCall", headers: headers, onResult: onResult)
+        return self.client.bidirectionalStream(path: "/grpc.testing.TestService/FullDuplexCall", headers: headers, onResult: onResult)
     }
 
     @available(iOS 13, *)
     internal func `fullDuplexCall`(headers: Connect.Headers = [:]) -> any Connect.BidirectionalAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
-        return self.client.bidirectionalStream(path: "grpc.testing.TestService/FullDuplexCall", headers: headers)
+        return self.client.bidirectionalStream(path: "/grpc.testing.TestService/FullDuplexCall", headers: headers)
     }
 
     internal func `halfDuplexCall`(headers: Connect.Headers = [:], onResult: @escaping (Connect.StreamResult<Grpc_Testing_StreamingOutputCallResponse>) -> Void) -> any Connect.BidirectionalStreamInterface<Grpc_Testing_StreamingOutputCallRequest> {
-        return self.client.bidirectionalStream(path: "grpc.testing.TestService/HalfDuplexCall", headers: headers, onResult: onResult)
+        return self.client.bidirectionalStream(path: "/grpc.testing.TestService/HalfDuplexCall", headers: headers, onResult: onResult)
     }
 
     @available(iOS 13, *)
     internal func `halfDuplexCall`(headers: Connect.Headers = [:]) -> any Connect.BidirectionalAsyncStreamInterface<Grpc_Testing_StreamingOutputCallRequest, Grpc_Testing_StreamingOutputCallResponse> {
-        return self.client.bidirectionalStream(path: "grpc.testing.TestService/HalfDuplexCall", headers: headers)
+        return self.client.bidirectionalStream(path: "/grpc.testing.TestService/HalfDuplexCall", headers: headers)
     }
 
     @discardableResult
     internal func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "grpc.testing.TestService/UnimplementedCall", request: request, headers: headers, completion: completion)
+        return self.client.unary(path: "/grpc.testing.TestService/UnimplementedCall", request: request, headers: headers, completion: completion)
     }
 
     @available(iOS 13, *)
     internal func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
-        return await self.client.unary(path: "grpc.testing.TestService/UnimplementedCall", request: request, headers: headers)
+        return await self.client.unary(path: "/grpc.testing.TestService/UnimplementedCall", request: request, headers: headers)
     }
 
     internal func `unimplementedStreamingOutputCall`(headers: Connect.Headers = [:], onResult: @escaping (Connect.StreamResult<Grpc_Testing_Empty>) -> Void) -> any Connect.ServerOnlyStreamInterface<Grpc_Testing_Empty> {
-        return self.client.serverOnlyStream(path: "grpc.testing.TestService/UnimplementedStreamingOutputCall", headers: headers, onResult: onResult)
+        return self.client.serverOnlyStream(path: "/grpc.testing.TestService/UnimplementedStreamingOutputCall", headers: headers, onResult: onResult)
     }
 
     @available(iOS 13, *)
     internal func `unimplementedStreamingOutputCall`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_Empty, Grpc_Testing_Empty> {
-        return self.client.serverOnlyStream(path: "grpc.testing.TestService/UnimplementedStreamingOutputCall", headers: headers)
+        return self.client.serverOnlyStream(path: "/grpc.testing.TestService/UnimplementedStreamingOutputCall", headers: headers)
     }
 
     internal enum Metadata {
@@ -275,21 +275,21 @@ internal final class Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimp
 
     @discardableResult
     internal func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "grpc.testing.UnimplementedService/UnimplementedCall", request: request, headers: headers, completion: completion)
+        return self.client.unary(path: "/grpc.testing.UnimplementedService/UnimplementedCall", request: request, headers: headers, completion: completion)
     }
 
     @available(iOS 13, *)
     internal func `unimplementedCall`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
-        return await self.client.unary(path: "grpc.testing.UnimplementedService/UnimplementedCall", request: request, headers: headers)
+        return await self.client.unary(path: "/grpc.testing.UnimplementedService/UnimplementedCall", request: request, headers: headers)
     }
 
     internal func `unimplementedStreamingOutputCall`(headers: Connect.Headers = [:], onResult: @escaping (Connect.StreamResult<Grpc_Testing_Empty>) -> Void) -> any Connect.ServerOnlyStreamInterface<Grpc_Testing_Empty> {
-        return self.client.serverOnlyStream(path: "grpc.testing.UnimplementedService/UnimplementedStreamingOutputCall", headers: headers, onResult: onResult)
+        return self.client.serverOnlyStream(path: "/grpc.testing.UnimplementedService/UnimplementedStreamingOutputCall", headers: headers, onResult: onResult)
     }
 
     @available(iOS 13, *)
     internal func `unimplementedStreamingOutputCall`(headers: Connect.Headers = [:]) -> any Connect.ServerOnlyAsyncStreamInterface<Grpc_Testing_Empty, Grpc_Testing_Empty> {
-        return self.client.serverOnlyStream(path: "grpc.testing.UnimplementedService/UnimplementedStreamingOutputCall", headers: headers)
+        return self.client.serverOnlyStream(path: "/grpc.testing.UnimplementedService/UnimplementedStreamingOutputCall", headers: headers)
     }
 
     internal enum Metadata {
@@ -326,22 +326,22 @@ internal final class Grpc_Testing_ReconnectServiceClient: Grpc_Testing_Reconnect
 
     @discardableResult
     internal func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "grpc.testing.ReconnectService/Start", request: request, headers: headers, completion: completion)
+        return self.client.unary(path: "/grpc.testing.ReconnectService/Start", request: request, headers: headers, completion: completion)
     }
 
     @available(iOS 13, *)
     internal func `start`(request: Grpc_Testing_ReconnectParams, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
-        return await self.client.unary(path: "grpc.testing.ReconnectService/Start", request: request, headers: headers)
+        return await self.client.unary(path: "/grpc.testing.ReconnectService/Start", request: request, headers: headers)
     }
 
     @discardableResult
     internal func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_ReconnectInfo>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "grpc.testing.ReconnectService/Stop", request: request, headers: headers, completion: completion)
+        return self.client.unary(path: "/grpc.testing.ReconnectService/Stop", request: request, headers: headers, completion: completion)
     }
 
     @available(iOS 13, *)
     internal func `stop`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_ReconnectInfo> {
-        return await self.client.unary(path: "grpc.testing.ReconnectService/Stop", request: request, headers: headers)
+        return await self.client.unary(path: "/grpc.testing.ReconnectService/Stop", request: request, headers: headers)
     }
 
     internal enum Metadata {
@@ -382,22 +382,22 @@ internal final class Grpc_Testing_LoadBalancerStatsServiceClient: Grpc_Testing_L
 
     @discardableResult
     internal func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientStats", request: request, headers: headers, completion: completion)
+        return self.client.unary(path: "/grpc.testing.LoadBalancerStatsService/GetClientStats", request: request, headers: headers, completion: completion)
     }
 
     @available(iOS 13, *)
     internal func `getClientStats`(request: Grpc_Testing_LoadBalancerStatsRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_LoadBalancerStatsResponse> {
-        return await self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientStats", request: request, headers: headers)
+        return await self.client.unary(path: "/grpc.testing.LoadBalancerStatsService/GetClientStats", request: request, headers: headers)
     }
 
     @discardableResult
     internal func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats", request: request, headers: headers, completion: completion)
+        return self.client.unary(path: "/grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats", request: request, headers: headers, completion: completion)
     }
 
     @available(iOS 13, *)
     internal func `getClientAccumulatedStats`(request: Grpc_Testing_LoadBalancerAccumulatedStatsRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_LoadBalancerAccumulatedStatsResponse> {
-        return await self.client.unary(path: "grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats", request: request, headers: headers)
+        return await self.client.unary(path: "/grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats", request: request, headers: headers)
     }
 
     internal enum Metadata {
@@ -434,22 +434,22 @@ internal final class Grpc_Testing_XdsUpdateHealthServiceClient: Grpc_Testing_Xds
 
     @discardableResult
     internal func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetServing", request: request, headers: headers, completion: completion)
+        return self.client.unary(path: "/grpc.testing.XdsUpdateHealthService/SetServing", request: request, headers: headers, completion: completion)
     }
 
     @available(iOS 13, *)
     internal func `setServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
-        return await self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetServing", request: request, headers: headers)
+        return await self.client.unary(path: "/grpc.testing.XdsUpdateHealthService/SetServing", request: request, headers: headers)
     }
 
     @discardableResult
     internal func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_Empty>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetNotServing", request: request, headers: headers, completion: completion)
+        return self.client.unary(path: "/grpc.testing.XdsUpdateHealthService/SetNotServing", request: request, headers: headers, completion: completion)
     }
 
     @available(iOS 13, *)
     internal func `setNotServing`(request: Grpc_Testing_Empty, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_Empty> {
-        return await self.client.unary(path: "grpc.testing.XdsUpdateHealthService/SetNotServing", request: request, headers: headers)
+        return await self.client.unary(path: "/grpc.testing.XdsUpdateHealthService/SetNotServing", request: request, headers: headers)
     }
 
     internal enum Metadata {
@@ -482,12 +482,12 @@ internal final class Grpc_Testing_XdsUpdateClientConfigureServiceClient: Grpc_Te
 
     @discardableResult
     internal func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:], completion: @escaping (ResponseMessage<Grpc_Testing_ClientConfigureResponse>) -> Void) -> Connect.Cancelable {
-        return self.client.unary(path: "grpc.testing.XdsUpdateClientConfigureService/Configure", request: request, headers: headers, completion: completion)
+        return self.client.unary(path: "/grpc.testing.XdsUpdateClientConfigureService/Configure", request: request, headers: headers, completion: completion)
     }
 
     @available(iOS 13, *)
     internal func `configure`(request: Grpc_Testing_ClientConfigureRequest, headers: Connect.Headers = [:]) async -> ResponseMessage<Grpc_Testing_ClientConfigureResponse> {
-        return await self.client.unary(path: "grpc.testing.XdsUpdateClientConfigureService/Configure", request: request, headers: headers)
+        return await self.client.unary(path: "/grpc.testing.XdsUpdateClientConfigureService/Configure", request: request, headers: headers)
     }
 
     internal enum Metadata {


### PR DESCRIPTION
This updates generated RPC paths to include leading slashes, which is in line with what `connect-go` does.

It also resolves issues with adding path components to the `host` flagged in https://github.com/bufbuild/connect-swift/issues/161.