### PR TITLE
Update crosstest reference text

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Outputted code will be available in the `out` directories specified by
 ## Running Tests
 
 A test server is used to run
-[crosstests](../Tests/ConnectLibraryTests/ConnectCrosstests) -
+[conformance](../Tests/ConnectLibraryTests/ConnectConformance) -
 integration tests which validate the behavior of the `Connect` library with
 various protocols. **Starting the server requires Docker,
 so ensure that you have Docker installed before proceeding.**
@@ -96,7 +96,7 @@ make test
 If you prefer to run the tests using Xcode, you can manually start the server:
 
 ```sh
-make crosstestserverrun
+make conformanceserverrun
 ```
 
 ## Linting

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ conformanceserverstop: ## Stop the conformance server
 .PHONY: conformanceserverrun
 conformanceserverrun: conformanceserverstop ## Start the conformance server
 	docker run --rm --name serverconnect -p 8080:8080 -p 8081:8081 -d \
-		connectrpc/conformance:$(CONFORMANCE_VERSION) \
+		bufbuild/connect-crosstest:$(CONFORMANCE_VERSION) \
 		/usr/local/bin/serverconnect --h1port "8080" --h2port "8081" --cert "cert/localhost.crt" --key "cert/localhost.key"
 	docker run --rm --name servergrpc -p 8083:8083 -d \
-		connectrpc/conformance:$(CONFORMANCE_VERSION) \
+		bufbuild/connect-crosstest:$(CONFORMANCE_VERSION) \
 		/usr/local/bin/servergrpc --port "8083" --cert "cert/localhost.crt" --key "cert/localhost.key"
 
 .PHONY: generate

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-print-directory
 BIN := .tmp/bin
 LICENSE_HEADER_YEAR_RANGE := 2022-2023
-CROSSTEST_VERSION := 4f4e96d8fea3ed9473b90a964a5ba429e7ea5649
+CONFORMANCE_VERSION := 4f4e96d8fea3ed9473b90a964a5ba429e7ea5649
 LICENSE_HEADER_VERSION := v1.12.0
 LICENSE_IGNORE := -e Package.swift \
     -e $(BIN)\/ \
@@ -40,17 +40,17 @@ cleangenerated: ## Delete all generated outputs
 	rm -rf ./Libraries/Connect/Implementation/Generated/*
 	rm -rf ./Tests/ConnectLibraryTests/Generated/*
 
-.PHONY: crosstestserverstop
-crosstestserverstop: ## Stop the crosstest server
+.PHONY: conformanceserverstop
+conformanceserverstop: ## Stop the conformance server
 	-docker container stop serverconnect servergrpc
 
-.PHONY: crosstestserverrun
-crosstestserverrun: crosstestserverstop ## Start the crosstest server
+.PHONY: conformanceserverrun
+conformanceserverrun: conformanceserverstop ## Start the conformance server
 	docker run --rm --name serverconnect -p 8080:8080 -p 8081:8081 -d \
-		bufbuild/connect-crosstest:$(CROSSTEST_VERSION) \
+		connectrpc/conformance:$(CONFORMANCE_VERSION) \
 		/usr/local/bin/serverconnect --h1port "8080" --h2port "8081" --cert "cert/localhost.crt" --key "cert/localhost.key"
 	docker run --rm --name servergrpc -p 8083:8083 -d \
-		bufbuild/connect-crosstest:$(CROSSTEST_VERSION) \
+		connectrpc/conformance:$(CONFORMANCE_VERSION) \
 		/usr/local/bin/servergrpc --port "8083" --cert "cert/localhost.crt" --key "cert/localhost.key"
 
 .PHONY: generate
@@ -78,6 +78,6 @@ $(BIN)/license-headers: Makefile
 	GOBIN=$(abspath $(BIN)) go install github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@$(LICENSE_HEADER_VERSION)
 
 .PHONY: test
-test: crosstestserverrun ## Run all tests
+test: conformanceserverrun ## Run all tests
 	swift test
-	$(MAKE) crosstestserverstop
+	$(MAKE) conformanceserverstop

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ for details.
 
 - [connect-kotlin][connect-kotlin]: Idiomatic gRPC & Connect RPCs for Kotlin
 - [connect-go][connect-go]: Go service stubs for servers
-- [connect-web][connect-web]: TypeScript clients for web browsers
+- [connect-es][connect-es]: Type-safe APIs with Protobuf and TypeScript
 - [Buf Studio][buf-studio]: Web UI for ad-hoc RPCs
-- [connect-crosstest][connect-crosstest]: Connect, gRPC, and gRPC-Web
+- [connect-conformance][connect-conformance]: Connect, gRPC, and gRPC-Web
   interoperability tests
 
 ## Status
@@ -171,11 +171,11 @@ Offered under the [Apache 2 license](./LICENSE).
 
 [blog]: https://buf.build/blog/announcing-connect-swift
 [buf-studio]: https://buf.build/studio
-[connect-crosstest]: https://github.com/bufbuild/connect-crosstest
+[connect-conformance]: https://github.com/connectrpc/conformance
 [connect-go]: https://github.com/bufbuild/connect-go
 [connect-kotlin]: https://github.com/bufbuild/connect-kotlin
 [connect-protocol]: https://connectrpc.com/docs/protocol
-[connect-web]: https://www.npmjs.com/package/@bufbuild/connect-web
+[connect-es]: https://github.com/connectrpc/connect-es
 [error-handling]: https://connectrpc.com/docs/swift/errors
 [getting-started]: https://connectrpc.com/docs/swift/getting-started
 [grpc-protocol]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md

--- a/Tests/ConnectLibraryTests/ConnectConformance/AsyncAwaitConformance.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/AsyncAwaitConformance.swift
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// swiftlint:disable file_length
-
 import Connect
 import Foundation
 import XCTest
@@ -24,73 +22,77 @@ private typealias TestServiceClient = Grpc_Testing_TestServiceClient
 private typealias UnimplementedServiceClient = Grpc_Testing_UnimplementedServiceClient
 
 /// This test suite runs against multiple protocols and serialization formats.
-/// Tests are based on https://github.com/bufbuild/connect-crosstest
+/// Tests are based on https://github.com/connectrpc/conformance
 ///
-/// Tests are written using callback APIs.
-final class CallbackCrosstests: XCTestCase {
+/// Tests are written using async/await APIs.
+@available(iOS 13, *)
+final class AsyncAwaitConformance: XCTestCase {
     private func executeTestWithClients(
         function: Selector = #function,
         timeout: TimeInterval = 60,
-        runTestsWithClient: (TestServiceClient) throws -> Void
-    ) rethrows {
-        let configurations = CrosstestConfiguration.all(timeout: timeout)
+        runTestsWithClient: (TestServiceClient) async throws -> Void
+    ) async rethrows {
+        let configurations = ConformanceConfiguration.all(timeout: timeout)
         for configuration in configurations {
-            try runTestsWithClient(TestServiceClient(client: configuration.protocolClient))
+            try await runTestsWithClient(TestServiceClient(client: configuration.protocolClient))
             print("Ran \(function) with \(configuration.description)")
         }
     }
 
     private func executeTestWithUnimplementedClients(
         function: Selector = #function,
-        runTestsWithClient: (UnimplementedServiceClient) throws -> Void
-    ) rethrows {
-        let configurations = CrosstestConfiguration.all(timeout: 60)
+        runTestsWithClient: (UnimplementedServiceClient) async throws -> Void
+    ) async rethrows {
+        let configurations = ConformanceConfiguration.all(timeout: 60)
         for configuration in configurations {
-            try runTestsWithClient(UnimplementedServiceClient(client: configuration.protocolClient))
+            try await runTestsWithClient(
+                UnimplementedServiceClient(client: configuration.protocolClient)
+            )
             print("Ran \(function) with \(configuration.description)")
         }
     }
 
-    // MARK: - Crosstest cases
+    // MARK: - Conformance cases
 
-    func testEmptyUnary() {
-        self.executeTestWithClients { client in
-            let expectation = self.expectation(description: "Receives successful response")
-            client.emptyCall(request: Grpc_Testing_Empty()) { response in
-                XCTAssertNil(response.error)
-                XCTAssertEqual(response.message, Grpc_Testing_Empty())
-                expectation.fulfill()
-            }
-            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
+    func testEmptyUnary() async {
+        await self.executeTestWithClients { client in
+            let response = await client.emptyCall(request: Grpc_Testing_Empty())
+            XCTAssertEqual(response.message, Grpc_Testing_Empty())
         }
     }
 
-    func testLargeUnary() {
-        self.executeTestWithClients { client in
+    func testLargeUnary() async {
+        await self.executeTestWithClients { client in
             let size = 314_159
             let message = Grpc_Testing_SimpleRequest.with { proto in
                 proto.responseSize = Int32(size)
                 proto.payload = .with { $0.body = Data(repeating: 0, count: size) }
             }
-            let expectation = self.expectation(description: "Receives successful response")
-            client.unaryCall(request: message) { response in
-                XCTAssertNil(response.error)
-                XCTAssertEqual(response.message?.payload.body.count, size)
-                expectation.fulfill()
-            }
-            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
+            let response = await client.unaryCall(request: message)
+            XCTAssertNil(response.error)
+            XCTAssertEqual(response.message?.payload.body.count, size)
         }
     }
 
-    func testServerStreaming() throws {
-        try self.executeTestWithClients { client in
+    func testServerStreaming() async throws {
+        try await self.executeTestWithClients { client in
             let sizes = [31_415, 9, 2_653, 58_979]
+            let stream = client.streamingOutputCall()
+            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
+                proto.responseParameters = sizes.enumerated().map { index, size in
+                    return .with { parameters in
+                        parameters.size = Int32(size)
+                        parameters.intervalUs = Int32(index * 10)
+                    }
+                }
+            })
+
             let expectation = self.expectation(description: "Stream completes")
             var responseCount = 0
-            let stream = client.streamingOutputCall { result in
+            for await result in stream.results() {
                 switch result {
                 case .headers:
-                    break
+                    continue
 
                 case .message(let output):
                     XCTAssertEqual(output.payload.body.count, sizes[responseCount])
@@ -102,27 +104,23 @@ final class CallbackCrosstests: XCTestCase {
                     expectation.fulfill()
                 }
             }
-            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
-                proto.responseParameters = sizes.enumerated().map { index, size in
-                    return .with { parameters in
-                        parameters.size = Int32(size)
-                        parameters.intervalUs = Int32(index * 10)
-                    }
-                }
-            })
 
             XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
             XCTAssertEqual(responseCount, 4)
         }
     }
 
-    func testEmptyStream() throws {
-        try self.executeTestWithClients { client in
+    func testEmptyStream() async throws {
+        try await self.executeTestWithClients { client in
             let closeExpectation = self.expectation(description: "Stream completes")
-            let stream = client.streamingOutputCall { result in
+            let stream = client.streamingOutputCall()
+            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
+                proto.responseParameters = []
+            })
+            for await result in stream.results() {
                 switch result {
                 case .headers:
-                    break
+                    continue
 
                 case .message:
                     XCTFail("Unexpectedly received message")
@@ -133,16 +131,13 @@ final class CallbackCrosstests: XCTestCase {
                     closeExpectation.fulfill()
                 }
             }
-            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
-                proto.responseParameters = []
-            })
 
             XCTAssertEqual(XCTWaiter().wait(for: [closeExpectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testCustomMetadata() {
-        self.executeTestWithClients { client in
+    func testCustomMetadata() async {
+        await self.executeTestWithClients { client in
             let size = 314_159
             let leadingKey = "x-grpc-test-echo-initial"
             let leadingValue = "test_initial_metadata_value"
@@ -157,23 +152,18 @@ final class CallbackCrosstests: XCTestCase {
                 proto.payload = .with { $0.body = Data(repeating: 0, count: size) }
             }
 
-            let expectation = self.expectation(description: "Receives response")
-            client.unaryCall(request: message, headers: headers) { response in
-                XCTAssertEqual(response.code, .ok)
-                XCTAssertNil(response.error)
-                XCTAssertEqual(response.headers[leadingKey], [leadingValue])
-                XCTAssertEqual(
-                    response.trailers[trailingKey], [trailingValue.base64EncodedString()]
-                )
-                XCTAssertEqual(response.message?.payload.body.count, size)
-                expectation.fulfill()
-            }
-
-            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
+            let response = await client.unaryCall(request: message, headers: headers)
+            XCTAssertEqual(response.code, .ok)
+            XCTAssertNil(response.error)
+            XCTAssertEqual(response.headers[leadingKey], [leadingValue])
+            XCTAssertEqual(
+                response.trailers[trailingKey], [trailingValue.base64EncodedString()]
+            )
+            XCTAssertEqual(response.message?.payload.body.count, size)
         }
     }
 
-    func testCustomMetadataServerStreaming() throws {
+    func testCustomMetadataServerStreaming() async throws {
         let size = 314_159
         let leadingKey = "x-grpc-test-echo-initial"
         let leadingValue = "test_initial_metadata_value"
@@ -184,11 +174,15 @@ final class CallbackCrosstests: XCTestCase {
             trailingKey: [trailingValue.base64EncodedString()],
         ]
 
-        try self.executeTestWithClients { client in
+        try await self.executeTestWithClients { client in
             let headersExpectation = self.expectation(description: "Receives headers")
             let messageExpectation = self.expectation(description: "Receives message")
             let trailersExpectation = self.expectation(description: "Receives trailers")
-            let stream = client.streamingOutputCall(headers: headers) { result in
+            let stream = client.streamingOutputCall(headers: headers)
+            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
+                proto.responseParameters = [.with { $0.size = Int32(size) }]
+            })
+            for await result in stream.results() {
                 switch result {
                 case .headers(let headers):
                     XCTAssertEqual(headers[leadingKey], [leadingValue])
@@ -205,9 +199,6 @@ final class CallbackCrosstests: XCTestCase {
                     trailersExpectation.fulfill()
                 }
             }
-            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
-                proto.responseParameters = [.with { $0.size = Int32(size) }]
-            })
 
             XCTAssertEqual(XCTWaiter().wait(for: [
                 headersExpectation, messageExpectation, trailersExpectation,
@@ -215,7 +206,7 @@ final class CallbackCrosstests: XCTestCase {
         }
     }
 
-    func testStatusCodeAndMessage() {
+    func testStatusCodeAndMessage() async {
         let message = Grpc_Testing_SimpleRequest.with { proto in
             proto.responseStatus = .with { status in
                 status.code = Int32(Code.unknown.rawValue)
@@ -223,25 +214,16 @@ final class CallbackCrosstests: XCTestCase {
             }
         }
 
-        self.executeTestWithClients { client in
-            let expectation = self.expectation(description: "Receives response")
-            client.unaryCall(request: message) { response in
-                guard let error = response.error else {
-                    XCTFail("Expected error response")
-                    return
-                }
-                XCTAssertEqual(error.code, .unknown)
-                XCTAssertEqual(error.message, "test status message")
-                expectation.fulfill()
-            }
-
-            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
+        await self.executeTestWithClients { client in
+            let response = await client.unaryCall(request: message)
+            XCTAssertEqual(response.error?.code, .unknown)
+            XCTAssertEqual(response.error?.message, "test status message")
         }
     }
 
-    func testSpecialStatus() {
+    func testSpecialStatus() async {
         let statusMessage =
-            "\\t\\ntest with whitespace\\r\\nand Unicode BMP ☺ and non-BMP \\uD83D\\uDE08\\t\\n"
+        "\\t\\ntest with whitespace\\r\\nand Unicode BMP ☺ and non-BMP \\uD83D\\uDE08\\t\\n"
         let message = Grpc_Testing_SimpleRequest.with { proto in
             proto.responseStatus = .with { status in
                 status.code = 2
@@ -249,24 +231,15 @@ final class CallbackCrosstests: XCTestCase {
             }
         }
 
-        self.executeTestWithClients { client in
-            let expectation = self.expectation(description: "Receives response")
-            client.unaryCall(request: message) { response in
-                guard let error = response.error else {
-                    XCTFail("Expected error response")
-                    return
-                }
-                XCTAssertEqual(error.code, .unknown)
-                XCTAssertEqual(error.message, statusMessage)
-                expectation.fulfill()
-            }
-
-            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
+        await self.executeTestWithClients { client in
+            let response = await client.unaryCall(request: message)
+            XCTAssertEqual(response.error?.code, .unknown)
+            XCTAssertEqual(response.error?.message, statusMessage)
         }
     }
 
-    func testTimeoutOnSleepingServer() throws {
-        try self.executeTestWithClients(timeout: 0.01) { client in
+    func testTimeoutOnSleepingServer() async throws {
+        try await self.executeTestWithClients(timeout: 0.01) { client in
             let expectation = self.expectation(description: "Stream times out")
             let message = Grpc_Testing_StreamingOutputCallRequest.with { proto in
                 proto.payload = .with { $0.body = Data(count: 271_828) }
@@ -277,13 +250,15 @@ final class CallbackCrosstests: XCTestCase {
                     },
                 ]
             }
-            let stream = client.streamingOutputCall { result in
+            let stream = client.streamingOutputCall()
+            try stream.send(message)
+            for await result in stream.results() {
                 switch result {
                 case .headers:
-                    break
+                    continue
 
                 case .message:
-                    break
+                    continue
 
                 case .complete(let code, let error, _):
                     XCTAssertEqual(code, .deadlineExceeded)
@@ -291,35 +266,31 @@ final class CallbackCrosstests: XCTestCase {
                     expectation.fulfill()
                 }
             }
-            try stream.send(message)
 
             XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testUnimplementedMethod() {
-        self.executeTestWithClients { client in
-            let expectation = self.expectation(description: "Request completes")
-            client.unimplementedCall(request: Grpc_Testing_Empty()) { response in
-                XCTAssertEqual(response.code, .unimplemented)
-                XCTAssertEqual(
-                    response.error?.message,
-                    "grpc.testing.TestService.UnimplementedCall is not implemented"
-                )
-                expectation.fulfill()
-            }
-
-            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
+    func testUnimplementedMethod() async {
+        await self.executeTestWithClients { client in
+            let response = await client.unimplementedCall(request: Grpc_Testing_Empty())
+            XCTAssertEqual(response.code, .unimplemented)
+            XCTAssertEqual(
+                response.error?.message,
+                "grpc.testing.TestService.UnimplementedCall is not implemented"
+            )
         }
     }
 
-    func testUnimplementedServerStreamingMethod() throws {
-        try self.executeTestWithClients { client in
+    func testUnimplementedServerStreamingMethod() async throws {
+        try await self.executeTestWithClients { client in
             let expectation = self.expectation(description: "Stream completes")
-            let stream = client.unimplementedStreamingOutputCall { result in
+            let stream = client.unimplementedStreamingOutputCall()
+            try stream.send(Grpc_Testing_Empty())
+            for await result in stream.results() {
                 switch result {
                 case .headers, .message:
-                    break
+                    continue
 
                 case .complete(let code, let error, _):
                     XCTAssertEqual(code, .unimplemented)
@@ -332,32 +303,28 @@ final class CallbackCrosstests: XCTestCase {
                     expectation.fulfill()
                 }
             }
-            try stream.send(Grpc_Testing_Empty())
 
             XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testUnimplementedService() {
-        self.executeTestWithUnimplementedClients { client in
-            let expectation = self.expectation(description: "Request completes")
-            client.unimplementedCall(request: Grpc_Testing_Empty()) { response in
-                XCTAssertEqual(response.code, .unimplemented)
-                XCTAssertNotNil(response.error)
-                expectation.fulfill()
-            }
-
-            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
+    func testUnimplementedService() async {
+        await self.executeTestWithUnimplementedClients { client in
+            let response = await client.unimplementedCall(request: Grpc_Testing_Empty())
+            XCTAssertEqual(response.code, .unimplemented)
+            XCTAssertNotNil(response.error)
         }
     }
 
-    func testUnimplementedServerStreamingService() throws {
-        try self.executeTestWithUnimplementedClients { client in
+    func testUnimplementedServerStreamingService() async throws {
+        try await self.executeTestWithUnimplementedClients { client in
             let expectation = self.expectation(description: "Stream completes")
-            let stream = client.unimplementedStreamingOutputCall { result in
+            let stream = client.unimplementedStreamingOutputCall()
+            try stream.send(Grpc_Testing_Empty())
+            for await result in stream.results() {
                 switch result {
                 case .headers:
-                    break
+                    continue
 
                 case .message:
                     XCTFail("Unexpectedly received message")
@@ -367,41 +334,46 @@ final class CallbackCrosstests: XCTestCase {
                     expectation.fulfill()
                 }
             }
-            try stream.send(Grpc_Testing_Empty())
 
             XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testFailUnary() {
-        self.executeTestWithClients { client in
+    func testFailUnary() async {
+        await self.executeTestWithClients { client in
             let expectedErrorDetail = Grpc_Testing_ErrorDetail.with { proto in
                 proto.reason = "soirée 🎉"
-                proto.domain = "connect-crosstest"
+                proto.domain = "connect-conformance"
             }
-            let expectation = self.expectation(description: "Request completes")
-            client.failUnaryCall(request: Grpc_Testing_SimpleRequest()) { response in
-                XCTAssertEqual(response.error?.code, .resourceExhausted)
-                XCTAssertEqual(response.error?.message, "soirée 🎉")
-                XCTAssertEqual(response.error?.unpackedDetails(), [expectedErrorDetail])
-                expectation.fulfill()
-            }
-
-            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
+            let response = await client.failUnaryCall(request: Grpc_Testing_SimpleRequest())
+            XCTAssertEqual(response.error?.code, .resourceExhausted)
+            XCTAssertEqual(response.error?.message, "soirée 🎉")
+            XCTAssertEqual(response.error?.unpackedDetails(), [expectedErrorDetail])
         }
     }
 
-    func testFailServerStreaming() throws {
-        try self.executeTestWithClients { client in
+    func testFailServerStreaming() async throws {
+        try await self.executeTestWithClients { client in
             let expectedErrorDetail = Grpc_Testing_ErrorDetail.with { proto in
                 proto.reason = "soirée 🎉"
-                proto.domain = "connect-crosstest"
+                proto.domain = "connect-conformance"
             }
             let expectation = self.expectation(description: "Stream completes")
-            let stream = client.failStreamingOutputCall { result in
+            let stream = client.failStreamingOutputCall()
+            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
+                proto.responseParameters = [31_415, 9, 2_653, 58_979]
+                    .enumerated()
+                    .map { index, value in
+                        return Grpc_Testing_ResponseParameters.with { parameters in
+                            parameters.size = Int32(value)
+                            parameters.intervalUs = Int32(index * 10)
+                        }
+                    }
+            })
+            for await result in stream.results() {
                 switch result {
                 case .headers:
-                    break
+                    continue
 
                 case .message:
                     XCTFail("Unexpectedly received message")
@@ -418,32 +390,7 @@ final class CallbackCrosstests: XCTestCase {
                     expectation.fulfill()
                 }
             }
-            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
-                proto.responseParameters = [31_415, 9, 2_653, 58_979]
-                    .enumerated()
-                    .map { index, value in
-                        return Grpc_Testing_ResponseParameters.with { parameters in
-                            parameters.size = Int32(value)
-                            parameters.intervalUs = Int32(index * 10)
-                        }
-                    }
-            })
 
-            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
-        }
-    }
-
-    // MARK: - Additional cases
-
-    func testCancelingUnary() {
-        self.executeTestWithClients { client in
-            let expectation = self.expectation(description: "Receives canceled response")
-            let cancelable = client.emptyCall(request: Grpc_Testing_Empty()) { response in
-                XCTAssertEqual(response.code, .canceled)
-                XCTAssertEqual(response.error?.code, .canceled)
-                expectation.fulfill()
-            }
-            cancelable.cancel()
             XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }

--- a/Tests/ConnectLibraryTests/ConnectConformance/AsyncAwaitConformance.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/AsyncAwaitConformance.swift
@@ -343,7 +343,7 @@ final class AsyncAwaitConformance: XCTestCase {
         await self.executeTestWithClients { client in
             let expectedErrorDetail = Grpc_Testing_ErrorDetail.with { proto in
                 proto.reason = "soirée 🎉"
-                proto.domain = "connect-conformance"
+                proto.domain = "connect-crosstest"
             }
             let response = await client.failUnaryCall(request: Grpc_Testing_SimpleRequest())
             XCTAssertEqual(response.error?.code, .resourceExhausted)
@@ -356,7 +356,7 @@ final class AsyncAwaitConformance: XCTestCase {
         try await self.executeTestWithClients { client in
             let expectedErrorDetail = Grpc_Testing_ErrorDetail.with { proto in
                 proto.reason = "soirée 🎉"
-                proto.domain = "connect-conformance"
+                proto.domain = "connect-crosstest"
             }
             let expectation = self.expectation(description: "Stream completes")
             let stream = client.failStreamingOutputCall()

--- a/Tests/ConnectLibraryTests/ConnectConformance/CallbackConformance.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/CallbackConformance.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// swiftlint:disable file_length
+
 import Connect
 import Foundation
 import XCTest
@@ -22,77 +24,73 @@ private typealias TestServiceClient = Grpc_Testing_TestServiceClient
 private typealias UnimplementedServiceClient = Grpc_Testing_UnimplementedServiceClient
 
 /// This test suite runs against multiple protocols and serialization formats.
-/// Tests are based on https://github.com/bufbuild/connect-crosstest
+/// Tests are based on https://github.com/connectrpc/conformance
 ///
-/// Tests are written using async/await APIs.
-@available(iOS 13, *)
-final class AsyncAwaitCrosstests: XCTestCase {
+/// Tests are written using callback APIs.
+final class CallbackConformance: XCTestCase {
     private func executeTestWithClients(
         function: Selector = #function,
         timeout: TimeInterval = 60,
-        runTestsWithClient: (TestServiceClient) async throws -> Void
-    ) async rethrows {
-        let configurations = CrosstestConfiguration.all(timeout: timeout)
+        runTestsWithClient: (TestServiceClient) throws -> Void
+    ) rethrows {
+        let configurations = ConformanceConfiguration.all(timeout: timeout)
         for configuration in configurations {
-            try await runTestsWithClient(TestServiceClient(client: configuration.protocolClient))
+            try runTestsWithClient(TestServiceClient(client: configuration.protocolClient))
             print("Ran \(function) with \(configuration.description)")
         }
     }
 
     private func executeTestWithUnimplementedClients(
         function: Selector = #function,
-        runTestsWithClient: (UnimplementedServiceClient) async throws -> Void
-    ) async rethrows {
-        let configurations = CrosstestConfiguration.all(timeout: 60)
+        runTestsWithClient: (UnimplementedServiceClient) throws -> Void
+    ) rethrows {
+        let configurations = ConformanceConfiguration.all(timeout: 60)
         for configuration in configurations {
-            try await runTestsWithClient(
-                UnimplementedServiceClient(client: configuration.protocolClient)
-            )
+            try runTestsWithClient(UnimplementedServiceClient(client: configuration.protocolClient))
             print("Ran \(function) with \(configuration.description)")
         }
     }
 
-    // MARK: - Crosstest cases
+    // MARK: - Conformance cases
 
-    func testEmptyUnary() async {
-        await self.executeTestWithClients { client in
-            let response = await client.emptyCall(request: Grpc_Testing_Empty())
-            XCTAssertEqual(response.message, Grpc_Testing_Empty())
+    func testEmptyUnary() {
+        self.executeTestWithClients { client in
+            let expectation = self.expectation(description: "Receives successful response")
+            client.emptyCall(request: Grpc_Testing_Empty()) { response in
+                XCTAssertNil(response.error)
+                XCTAssertEqual(response.message, Grpc_Testing_Empty())
+                expectation.fulfill()
+            }
+            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testLargeUnary() async {
-        await self.executeTestWithClients { client in
+    func testLargeUnary() {
+        self.executeTestWithClients { client in
             let size = 314_159
             let message = Grpc_Testing_SimpleRequest.with { proto in
                 proto.responseSize = Int32(size)
                 proto.payload = .with { $0.body = Data(repeating: 0, count: size) }
             }
-            let response = await client.unaryCall(request: message)
-            XCTAssertNil(response.error)
-            XCTAssertEqual(response.message?.payload.body.count, size)
+            let expectation = self.expectation(description: "Receives successful response")
+            client.unaryCall(request: message) { response in
+                XCTAssertNil(response.error)
+                XCTAssertEqual(response.message?.payload.body.count, size)
+                expectation.fulfill()
+            }
+            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testServerStreaming() async throws {
-        try await self.executeTestWithClients { client in
+    func testServerStreaming() throws {
+        try self.executeTestWithClients { client in
             let sizes = [31_415, 9, 2_653, 58_979]
-            let stream = client.streamingOutputCall()
-            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
-                proto.responseParameters = sizes.enumerated().map { index, size in
-                    return .with { parameters in
-                        parameters.size = Int32(size)
-                        parameters.intervalUs = Int32(index * 10)
-                    }
-                }
-            })
-
             let expectation = self.expectation(description: "Stream completes")
             var responseCount = 0
-            for await result in stream.results() {
+            let stream = client.streamingOutputCall { result in
                 switch result {
                 case .headers:
-                    continue
+                    break
 
                 case .message(let output):
                     XCTAssertEqual(output.payload.body.count, sizes[responseCount])
@@ -104,23 +102,27 @@ final class AsyncAwaitCrosstests: XCTestCase {
                     expectation.fulfill()
                 }
             }
+            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
+                proto.responseParameters = sizes.enumerated().map { index, size in
+                    return .with { parameters in
+                        parameters.size = Int32(size)
+                        parameters.intervalUs = Int32(index * 10)
+                    }
+                }
+            })
 
             XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
             XCTAssertEqual(responseCount, 4)
         }
     }
 
-    func testEmptyStream() async throws {
-        try await self.executeTestWithClients { client in
+    func testEmptyStream() throws {
+        try self.executeTestWithClients { client in
             let closeExpectation = self.expectation(description: "Stream completes")
-            let stream = client.streamingOutputCall()
-            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
-                proto.responseParameters = []
-            })
-            for await result in stream.results() {
+            let stream = client.streamingOutputCall { result in
                 switch result {
                 case .headers:
-                    continue
+                    break
 
                 case .message:
                     XCTFail("Unexpectedly received message")
@@ -131,13 +133,16 @@ final class AsyncAwaitCrosstests: XCTestCase {
                     closeExpectation.fulfill()
                 }
             }
+            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
+                proto.responseParameters = []
+            })
 
             XCTAssertEqual(XCTWaiter().wait(for: [closeExpectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testCustomMetadata() async {
-        await self.executeTestWithClients { client in
+    func testCustomMetadata() {
+        self.executeTestWithClients { client in
             let size = 314_159
             let leadingKey = "x-grpc-test-echo-initial"
             let leadingValue = "test_initial_metadata_value"
@@ -152,18 +157,23 @@ final class AsyncAwaitCrosstests: XCTestCase {
                 proto.payload = .with { $0.body = Data(repeating: 0, count: size) }
             }
 
-            let response = await client.unaryCall(request: message, headers: headers)
-            XCTAssertEqual(response.code, .ok)
-            XCTAssertNil(response.error)
-            XCTAssertEqual(response.headers[leadingKey], [leadingValue])
-            XCTAssertEqual(
-                response.trailers[trailingKey], [trailingValue.base64EncodedString()]
-            )
-            XCTAssertEqual(response.message?.payload.body.count, size)
+            let expectation = self.expectation(description: "Receives response")
+            client.unaryCall(request: message, headers: headers) { response in
+                XCTAssertEqual(response.code, .ok)
+                XCTAssertNil(response.error)
+                XCTAssertEqual(response.headers[leadingKey], [leadingValue])
+                XCTAssertEqual(
+                    response.trailers[trailingKey], [trailingValue.base64EncodedString()]
+                )
+                XCTAssertEqual(response.message?.payload.body.count, size)
+                expectation.fulfill()
+            }
+
+            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testCustomMetadataServerStreaming() async throws {
+    func testCustomMetadataServerStreaming() throws {
         let size = 314_159
         let leadingKey = "x-grpc-test-echo-initial"
         let leadingValue = "test_initial_metadata_value"
@@ -174,15 +184,11 @@ final class AsyncAwaitCrosstests: XCTestCase {
             trailingKey: [trailingValue.base64EncodedString()],
         ]
 
-        try await self.executeTestWithClients { client in
+        try self.executeTestWithClients { client in
             let headersExpectation = self.expectation(description: "Receives headers")
             let messageExpectation = self.expectation(description: "Receives message")
             let trailersExpectation = self.expectation(description: "Receives trailers")
-            let stream = client.streamingOutputCall(headers: headers)
-            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
-                proto.responseParameters = [.with { $0.size = Int32(size) }]
-            })
-            for await result in stream.results() {
+            let stream = client.streamingOutputCall(headers: headers) { result in
                 switch result {
                 case .headers(let headers):
                     XCTAssertEqual(headers[leadingKey], [leadingValue])
@@ -199,6 +205,9 @@ final class AsyncAwaitCrosstests: XCTestCase {
                     trailersExpectation.fulfill()
                 }
             }
+            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
+                proto.responseParameters = [.with { $0.size = Int32(size) }]
+            })
 
             XCTAssertEqual(XCTWaiter().wait(for: [
                 headersExpectation, messageExpectation, trailersExpectation,
@@ -206,7 +215,7 @@ final class AsyncAwaitCrosstests: XCTestCase {
         }
     }
 
-    func testStatusCodeAndMessage() async {
+    func testStatusCodeAndMessage() {
         let message = Grpc_Testing_SimpleRequest.with { proto in
             proto.responseStatus = .with { status in
                 status.code = Int32(Code.unknown.rawValue)
@@ -214,16 +223,25 @@ final class AsyncAwaitCrosstests: XCTestCase {
             }
         }
 
-        await self.executeTestWithClients { client in
-            let response = await client.unaryCall(request: message)
-            XCTAssertEqual(response.error?.code, .unknown)
-            XCTAssertEqual(response.error?.message, "test status message")
+        self.executeTestWithClients { client in
+            let expectation = self.expectation(description: "Receives response")
+            client.unaryCall(request: message) { response in
+                guard let error = response.error else {
+                    XCTFail("Expected error response")
+                    return
+                }
+                XCTAssertEqual(error.code, .unknown)
+                XCTAssertEqual(error.message, "test status message")
+                expectation.fulfill()
+            }
+
+            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testSpecialStatus() async {
+    func testSpecialStatus() {
         let statusMessage =
-        "\\t\\ntest with whitespace\\r\\nand Unicode BMP ☺ and non-BMP \\uD83D\\uDE08\\t\\n"
+            "\\t\\ntest with whitespace\\r\\nand Unicode BMP ☺ and non-BMP \\uD83D\\uDE08\\t\\n"
         let message = Grpc_Testing_SimpleRequest.with { proto in
             proto.responseStatus = .with { status in
                 status.code = 2
@@ -231,15 +249,24 @@ final class AsyncAwaitCrosstests: XCTestCase {
             }
         }
 
-        await self.executeTestWithClients { client in
-            let response = await client.unaryCall(request: message)
-            XCTAssertEqual(response.error?.code, .unknown)
-            XCTAssertEqual(response.error?.message, statusMessage)
+        self.executeTestWithClients { client in
+            let expectation = self.expectation(description: "Receives response")
+            client.unaryCall(request: message) { response in
+                guard let error = response.error else {
+                    XCTFail("Expected error response")
+                    return
+                }
+                XCTAssertEqual(error.code, .unknown)
+                XCTAssertEqual(error.message, statusMessage)
+                expectation.fulfill()
+            }
+
+            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testTimeoutOnSleepingServer() async throws {
-        try await self.executeTestWithClients(timeout: 0.01) { client in
+    func testTimeoutOnSleepingServer() throws {
+        try self.executeTestWithClients(timeout: 0.01) { client in
             let expectation = self.expectation(description: "Stream times out")
             let message = Grpc_Testing_StreamingOutputCallRequest.with { proto in
                 proto.payload = .with { $0.body = Data(count: 271_828) }
@@ -250,15 +277,13 @@ final class AsyncAwaitCrosstests: XCTestCase {
                     },
                 ]
             }
-            let stream = client.streamingOutputCall()
-            try stream.send(message)
-            for await result in stream.results() {
+            let stream = client.streamingOutputCall { result in
                 switch result {
                 case .headers:
-                    continue
+                    break
 
                 case .message:
-                    continue
+                    break
 
                 case .complete(let code, let error, _):
                     XCTAssertEqual(code, .deadlineExceeded)
@@ -266,31 +291,35 @@ final class AsyncAwaitCrosstests: XCTestCase {
                     expectation.fulfill()
                 }
             }
+            try stream.send(message)
 
             XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testUnimplementedMethod() async {
-        await self.executeTestWithClients { client in
-            let response = await client.unimplementedCall(request: Grpc_Testing_Empty())
-            XCTAssertEqual(response.code, .unimplemented)
-            XCTAssertEqual(
-                response.error?.message,
-                "grpc.testing.TestService.UnimplementedCall is not implemented"
-            )
+    func testUnimplementedMethod() {
+        self.executeTestWithClients { client in
+            let expectation = self.expectation(description: "Request completes")
+            client.unimplementedCall(request: Grpc_Testing_Empty()) { response in
+                XCTAssertEqual(response.code, .unimplemented)
+                XCTAssertEqual(
+                    response.error?.message,
+                    "grpc.testing.TestService.UnimplementedCall is not implemented"
+                )
+                expectation.fulfill()
+            }
+
+            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testUnimplementedServerStreamingMethod() async throws {
-        try await self.executeTestWithClients { client in
+    func testUnimplementedServerStreamingMethod() throws {
+        try self.executeTestWithClients { client in
             let expectation = self.expectation(description: "Stream completes")
-            let stream = client.unimplementedStreamingOutputCall()
-            try stream.send(Grpc_Testing_Empty())
-            for await result in stream.results() {
+            let stream = client.unimplementedStreamingOutputCall { result in
                 switch result {
                 case .headers, .message:
-                    continue
+                    break
 
                 case .complete(let code, let error, _):
                     XCTAssertEqual(code, .unimplemented)
@@ -303,28 +332,32 @@ final class AsyncAwaitCrosstests: XCTestCase {
                     expectation.fulfill()
                 }
             }
+            try stream.send(Grpc_Testing_Empty())
 
             XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testUnimplementedService() async {
-        await self.executeTestWithUnimplementedClients { client in
-            let response = await client.unimplementedCall(request: Grpc_Testing_Empty())
-            XCTAssertEqual(response.code, .unimplemented)
-            XCTAssertNotNil(response.error)
+    func testUnimplementedService() {
+        self.executeTestWithUnimplementedClients { client in
+            let expectation = self.expectation(description: "Request completes")
+            client.unimplementedCall(request: Grpc_Testing_Empty()) { response in
+                XCTAssertEqual(response.code, .unimplemented)
+                XCTAssertNotNil(response.error)
+                expectation.fulfill()
+            }
+
+            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testUnimplementedServerStreamingService() async throws {
-        try await self.executeTestWithUnimplementedClients { client in
+    func testUnimplementedServerStreamingService() throws {
+        try self.executeTestWithUnimplementedClients { client in
             let expectation = self.expectation(description: "Stream completes")
-            let stream = client.unimplementedStreamingOutputCall()
-            try stream.send(Grpc_Testing_Empty())
-            for await result in stream.results() {
+            let stream = client.unimplementedStreamingOutputCall { result in
                 switch result {
                 case .headers:
-                    continue
+                    break
 
                 case .message:
                     XCTFail("Unexpectedly received message")
@@ -334,46 +367,41 @@ final class AsyncAwaitCrosstests: XCTestCase {
                     expectation.fulfill()
                 }
             }
+            try stream.send(Grpc_Testing_Empty())
 
             XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testFailUnary() async {
-        await self.executeTestWithClients { client in
+    func testFailUnary() {
+        self.executeTestWithClients { client in
             let expectedErrorDetail = Grpc_Testing_ErrorDetail.with { proto in
                 proto.reason = "soirée 🎉"
-                proto.domain = "connect-crosstest"
+                proto.domain = "connect-conformance"
             }
-            let response = await client.failUnaryCall(request: Grpc_Testing_SimpleRequest())
-            XCTAssertEqual(response.error?.code, .resourceExhausted)
-            XCTAssertEqual(response.error?.message, "soirée 🎉")
-            XCTAssertEqual(response.error?.unpackedDetails(), [expectedErrorDetail])
+            let expectation = self.expectation(description: "Request completes")
+            client.failUnaryCall(request: Grpc_Testing_SimpleRequest()) { response in
+                XCTAssertEqual(response.error?.code, .resourceExhausted)
+                XCTAssertEqual(response.error?.message, "soirée 🎉")
+                XCTAssertEqual(response.error?.unpackedDetails(), [expectedErrorDetail])
+                expectation.fulfill()
+            }
+
+            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }
 
-    func testFailServerStreaming() async throws {
-        try await self.executeTestWithClients { client in
+    func testFailServerStreaming() throws {
+        try self.executeTestWithClients { client in
             let expectedErrorDetail = Grpc_Testing_ErrorDetail.with { proto in
                 proto.reason = "soirée 🎉"
-                proto.domain = "connect-crosstest"
+                proto.domain = "connect-conformance"
             }
             let expectation = self.expectation(description: "Stream completes")
-            let stream = client.failStreamingOutputCall()
-            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
-                proto.responseParameters = [31_415, 9, 2_653, 58_979]
-                    .enumerated()
-                    .map { index, value in
-                        return Grpc_Testing_ResponseParameters.with { parameters in
-                            parameters.size = Int32(value)
-                            parameters.intervalUs = Int32(index * 10)
-                        }
-                    }
-            })
-            for await result in stream.results() {
+            let stream = client.failStreamingOutputCall { result in
                 switch result {
                 case .headers:
-                    continue
+                    break
 
                 case .message:
                     XCTFail("Unexpectedly received message")
@@ -390,7 +418,32 @@ final class AsyncAwaitCrosstests: XCTestCase {
                     expectation.fulfill()
                 }
             }
+            try stream.send(Grpc_Testing_StreamingOutputCallRequest.with { proto in
+                proto.responseParameters = [31_415, 9, 2_653, 58_979]
+                    .enumerated()
+                    .map { index, value in
+                        return Grpc_Testing_ResponseParameters.with { parameters in
+                            parameters.size = Int32(value)
+                            parameters.intervalUs = Int32(index * 10)
+                        }
+                    }
+            })
 
+            XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
+        }
+    }
+
+    // MARK: - Additional cases
+
+    func testCancelingUnary() {
+        self.executeTestWithClients { client in
+            let expectation = self.expectation(description: "Receives canceled response")
+            let cancelable = client.emptyCall(request: Grpc_Testing_Empty()) { response in
+                XCTAssertEqual(response.code, .canceled)
+                XCTAssertEqual(response.error?.code, .canceled)
+                expectation.fulfill()
+            }
+            cancelable.cancel()
             XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: kTimeout), .completed)
         }
     }

--- a/Tests/ConnectLibraryTests/ConnectConformance/CallbackConformance.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/CallbackConformance.swift
@@ -377,7 +377,7 @@ final class CallbackConformance: XCTestCase {
         self.executeTestWithClients { client in
             let expectedErrorDetail = Grpc_Testing_ErrorDetail.with { proto in
                 proto.reason = "soirée 🎉"
-                proto.domain = "connect-conformance"
+                proto.domain = "connect-crosstest"
             }
             let expectation = self.expectation(description: "Request completes")
             client.failUnaryCall(request: Grpc_Testing_SimpleRequest()) { response in
@@ -395,7 +395,7 @@ final class CallbackConformance: XCTestCase {
         try self.executeTestWithClients { client in
             let expectedErrorDetail = Grpc_Testing_ErrorDetail.with { proto in
                 proto.reason = "soirée 🎉"
-                proto.domain = "connect-conformance"
+                proto.domain = "connect-crosstest"
             }
             let expectation = self.expectation(description: "Stream completes")
             let stream = client.failStreamingOutputCall { result in

--- a/Tests/ConnectLibraryTests/ConnectConformance/ConformanceConfiguration.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/ConformanceConfiguration.swift
@@ -16,8 +16,8 @@ import Connect
 import ConnectNIO
 import Foundation
 
-/// Represents a specific configuration with which to run a suite of crosstests.
-final class CrosstestConfiguration {
+/// Represents a specific configuration with which to run a suite of conformance tests.
+final class ConformanceConfiguration {
     let description: String
     let protocolClient: ProtocolClient
 
@@ -27,14 +27,14 @@ final class CrosstestConfiguration {
     }
 
     /// Configures a list of configurations that can be used to run a comprehensive
-    /// suite of crosstests.
+    /// suite of conformance tests.
     ///
     /// - parameter timeout: Timeout to apply to the client.
     ///
-    /// - returns: A list of configurations to use for crosstests.
-    static func all(timeout: TimeInterval) -> [CrosstestConfiguration] {
-        let urlSessionClient = CrosstestURLSessionHTTPClient(timeout: timeout)
-        let nioClient = CrosstestNIOHTTPClient(
+    /// - returns: A list of configurations to use for conformance tests.
+    static func all(timeout: TimeInterval) -> [ConformanceConfiguration] {
+        let urlSessionClient = ConformanceURLSessionHTTPClient(timeout: timeout)
+        let nioClient = ConformanceNIOHTTPClient(
             // swiftlint:disable:next number_separator
             host: "https://localhost", port: 8081, timeout: timeout
         )

--- a/Tests/ConnectLibraryTests/ConnectConformance/ConformanceNIOHTTPClient.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/ConformanceNIOHTTPClient.swift
@@ -17,9 +17,9 @@ import ConnectNIO
 import Foundation
 import NIOSSL
 
-/// HTTP client backed by NIO and used by crosstests in order to handle SSL challenges
-/// with the crosstest server.
-final class CrosstestNIOHTTPClient: ConnectNIO.NIOHTTPClient {
+/// HTTP client backed by NIO and used by conformance tests in order to handle SSL challenges
+/// with the conformance server.
+final class ConformanceNIOHTTPClient: ConnectNIO.NIOHTTPClient {
     init(host: String, port: Int, timeout: TimeInterval) {
         super.init(host: host, port: port, timeout: timeout)
     }

--- a/Tests/ConnectLibraryTests/ConnectConformance/ConformanceURLSessionHTTPClient.swift
+++ b/Tests/ConnectLibraryTests/ConnectConformance/ConformanceURLSessionHTTPClient.swift
@@ -15,9 +15,9 @@
 import Connect
 import Foundation
 
-/// HTTP client backed by URLSession and used by crosstests in order to handle SSL challenges
-/// with the crosstest server.
-final class CrosstestURLSessionHTTPClient: URLSessionHTTPClient {
+/// HTTP client backed by URLSession and used by conformance tests in order to handle SSL challenges
+/// with the conformance server.
+final class ConformanceURLSessionHTTPClient: URLSessionHTTPClient {
     init(timeout: TimeInterval) {
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = timeout
@@ -29,7 +29,7 @@ final class CrosstestURLSessionHTTPClient: URLSessionHTTPClient {
         _ session: URLSession, didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
-        // This codepath is executed when using HTTPS with the crosstest server.
+        // This codepath is executed when using HTTPS with the conformance server.
         let protectionSpace = challenge.protectionSpace
         if protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
            let serverTrust = protectionSpace.serverTrust

--- a/Tests/ConnectLibraryTests/proto/README.md
+++ b/Tests/ConnectLibraryTests/proto/README.md
@@ -1,2 +1,2 @@
 This directory contains `.proto` files that are used to communicate
-with the crosstest server when running tests.
+with the conformance server when running tests.


### PR DESCRIPTION
This updates references to the crosstest repo to use conformance instead.

Note that the Docker image used for crosstests still uses an old bufbuild image. This is because the test proto packages have changed in the new repo and switching to use one of the new images would cause all existing code to break. This will be fixed in a follow-up PR.